### PR TITLE
Organize PRD instruction library

### DIFF
--- a/docs/REPO-ORGANIZATION.md
+++ b/docs/REPO-ORGANIZATION.md
@@ -35,7 +35,7 @@ updated: "2025-02-14"
 │   └── ...
 ├── src/              # Application code
 ├── tests/            # Automated tests
-├── docs/             # Supporting docs (ID Knowledge Graph, decision logs)
+├── docs/             # Supporting docs (ID Knowledge Graph, decision logs, PRD instruction library)
 ├── temp/             # Short-lived scratchpads (purge or harvest every EPIC)
 ├── archive/          # Frozen history (YYYY-MM folders)
 └── tools/            # Automation scripts (metrics, registry sync)

--- a/docs/prd/instructions/README.md
+++ b/docs/prd/instructions/README.md
@@ -1,0 +1,18 @@
+# PRD Instruction Library
+
+This directory organizes workflow instructions that guide each stage of the Product Requirements Document (PRD) lifecycle.
+
+## Structure
+- `README.md`: This file. Describes how to navigate the instruction library.
+- `vX.Y/`: Versioned subdirectories that capture the instructions required to produce and advance that PRD milestone.
+  - `research-agents.md`: Guidance for research agents producing idea sparks and evidence bundles.
+  - `aura-intake.md`: Guidance for the AURA drafting agent that converts research bundles into PRD deliverables.
+  - Additional files may be added as new roles join the stage (e.g., validation playbooks, engineering intake guides).
+
+## Usage Guidelines
+1. Each stage should host **one to three** role-specific instruction files that align with Gear Heart Methodology (GHM) checkpoints.
+2. Instruction files must describe how outputs map into the Source-of-Truth (SoT) graph and note any lifecycle hooks for the next PRD version.
+3. When introducing a new stage, create a new `vX.Y/` directory, populate the relevant instructions, and cross-link them from the previous stage as needed.
+4. Keep filenames consistent across stages (e.g., `research-agents.md`, `aura-intake.md`) so downstream automation can locate role guides predictably.
+
+By centralizing the instructions here, we make it easier for research, drafting, and validation agents to adopt a shared workflow while scaling additional PRD phases.

--- a/docs/prd/instructions/v0.1/aura-intake.md
+++ b/docs/prd/instructions/v0.1/aura-intake.md
@@ -1,0 +1,86 @@
+# PRD v0.1 AURA Intake Instructions
+
+> Part of the PRD Instruction Library (`docs/prd/instructions/`). Keep filenames and structure consistent when cloning for future PRD stages.
+
+## Mission Alignment
+**Objective:** Transform validated research idea sparks into the PRD v0.1 draft covering Problem, Users, Value Proposition, and Future Work without breaking Gear Heart Methodology (GHM) discipline.
+**Inputs:** Research bundles produced with the [PRD v0.1 Research Agent Instructions](./research-agents.md). Assume facts, links, and quotes are already verified and mapped to candidate SoT IDs.
+**Deliverable:** A PRD v0.1 packet per idea that is ready for cross-functional review and prioritization, including next-ID recommendations for the Source-of-Truth (SoT) library.
+
+## Intake Checklist
+Before drafting, confirm the bundle includes:
+- Summary Sheet with Idea ID, Industry, Primary Pain Point, and MVP hook
+- Completed Output Template (all sections populated)
+- Pricing and community evidence files named `[idea-id]__[artifact-type].*`
+- Hand-off note suggesting Opportunity and High-Level Solution framing + lifecycle next step (e.g., "promote to v0.2 once ICP confirmed")
+- Assumptions & Open Questions enumerated
+- Methodology signal showing PRD sections impacted and proposed SoT IDs
+
+If any item is missing, flag the gap to the research lead before proceeding.
+
+## Processing Workflow
+1. **Bundle Review:** Read the Summary Sheet to select the idea(s) for drafting. Confirm the methodology signal covers PRD sections + candidate IDs, then use the `ARTIFACTS FOR AURA` references to locate supporting files.
+2. **Problem Synthesis:** Extract the Primary Pain Point, demand signals, and community quotes to craft a concise Problem statement. Highlight quantified impact.
+3. **User Definition:** Translate the Ideal Customer Profile into explicit user personas (roles, organization size, operational context). Note any assumptions supplied and tie each persona to eventual UJ- IDs.
+4. **Value Proposition:** Combine MVP Scope and Market Validation to articulate the promised outcomes and differentiators versus competitors. Document which BR-/CFD- IDs will capture supporting rules or feedback.
+5. **Future Work Hooks:** Leverage the Assumptions & Open Questions and Hand-off note to outline potential extensions, risks, and validation tasks. Identify the PRD lifecycle stage to pursue next.
+6. **Traceability Tagging:** Cite Idea ID, artifact filenames, and proposed IDs inline so reviewers can jump back to evidence quickly and register new SoT cards.
+7. **Review & Polish:** Ensure clarity, consistent terminology, and that no new facts are introduced without evidence from the bundle. Confirm the draft signals readiness for the v0.1 gate review.
+
+## Output Template (per idea)
+```
+# [Idea ID] – PRD v0.1 Draft
+
+## Problem
+[2-3 paragraphs summarizing the workflow pain, quantified impact, and context. Include citations like (Artifact: pricing1.png).]
+
+## Target Users
+- Primary persona: [Role, organization size, workflow trigger]
+- Secondary persona(s): [If applicable]
+- Assumptions: [Borrowed from research; note any unresolved questions]
+
+## Value Proposition
+- Core outcome: [What success looks like for the user]
+- Differentiators: [Why this solution beats competitors, referencing demand signals]
+- MVP Scope Alignment: [How the MVP feature set delivers the outcome]
+- SoT Hooks: [List BR-/CFD- IDs to instantiate with this draft]
+
+## Future Work & Validation
+- Near-term experiments: [Customer interviews, pilot metrics]
+- Expansion ideas: [Potential next features, integrations]
+- Risks & mitigation: [Gaps from Assumptions/Open Questions]
+- Lifecycle Next Step: [What milestone to schedule (e.g., v0.2 Market Definition)]
+
+## Evidence Index
+| Artifact | Description | Usage in Draft |
+|----------|-------------|----------------|
+| [idea-id]__pricing1.png | Competitor pricing capture | Problem (market willingness to pay)
+| ... | ... | ... |
+
+## ID Register Stub
+- Proposed IDs: [List candidate CFD-/BR-/UJ- entries, even if placeholders]
+- Dependencies: [Cross-reference existing IDs this work touches]
+```
+
+## Quality Gates
+| Checkpoint | Pass Condition |
+|------------|----------------|
+| **Problem Clarity** | Pain point is stated with quantifiable stakes pulled from research evidence. |
+| **User Fit** | Personas mirror the Ideal Customer Profile with any assumptions explicitly tagged. |
+| **Evidence Traceability** | Every claim references a linked artifact or quote and lists the supporting artifact ID/file. |
+| **Scope Discipline** | MVP description sticks to features validated by research; no new scope creep. |
+| **Future Work Utility** | Actionable next steps stem from Assumptions & Open Questions, not speculation, and include lifecycle planning. |
+| **ID Hygiene** | Candidate SoT IDs are listed with owners or next steps for creation. |
+
+## Handoff & Collaboration
+- Store PRD drafts alongside the research bundle using the naming convention `[idea-id]__prd-v0.1.md`.
+- Post a summary update highlighting key insights, flagged risks, and any additional information requests for researchers.
+- If facts appear inconsistent, annotate the draft and request clarification instead of rewriting evidence.
+
+## Reporting Checklist
+- [ ] PRD draft saved with correct file name
+- [ ] All sections completed using the template
+- [ ] Evidence Index populated and cross-referenced
+- [ ] ID Register Stub filled in and linked to SoT backlog
+- [ ] Outstanding questions escalated to research lead
+- [ ] Summary update shared with product stakeholders, including lifecycle recommendation

--- a/docs/prd/instructions/v0.1/research-agents.md
+++ b/docs/prd/instructions/v0.1/research-agents.md
@@ -1,0 +1,90 @@
+# PRD v0.1 Research Agent Instructions
+
+> Part of the PRD Instruction Library (`docs/prd/instructions/`). Keep filenames and structure consistent when cloning for future PRD stages.
+
+## Mission Alignment
+**Objective:** Generate validated vertical micro-SaaS sparks that can seed the PRD v0.1 for AURA while respecting the Gear Heart Methodology (GHM) gates.
+**Downstream Consumer:** AURA uses your output to draft the Problem, Users, Value Proposition, and Future Work sections of the PRD. Assume AURA will not re-verify facts, but will map your evidence into PRD + SoT IDs.
+**Deliverable Count:** Provide 3-5 distinct ideas per assignment unless otherwise specified. Each idea must target a different vertical.
+**Methodology Alignment:** Treat each idea as the seed for future CFD-/BR-/UJ- IDs. Highlight where the research should land in the PRD Version Lifecycle (v0.1 Spark today, v0.2+ later).
+
+## Research Workflow
+1. **Kick-off Summary (Optional but encouraged):** Record a single paragraph describing the search strategy, keywords, and data sources explored.
+2. **Idea Exploration:** Use demand signals from the past 24 months (newsletters, funding rounds, marketplace chatter) to shortlist opportunities.
+3. **Validation:** Confirm all requirements in the Quality Gates table before preparing the output.
+4. **Evidence Capture:** Save primary source links and archive copies (via screenshots or PDFs) for competitor pricing and community posts.
+5. **Handoff Package:** Deliver one consolidated document or thread per idea following the Output Template, accompanied by a resource bundle (links + file references) so AURA can ingest everything without rerunning searches.
+
+## Output Template (per idea)
+🎯 **IDEA:** [Name – ≤30 words, elevator pitch]
+
+🧾 **IDEA ID:** [Short slug, e.g., "dental-lab-qc"]
+📍 **TARGET INDUSTRY:** [Specific vertical, e.g., "Independent dental labs"]
+🎯 **IDEAL CUSTOMER PROFILE:** [Role + organization size]
+
+🧠 **GHM ALIGNMENT:**
+   ├─ PRD Targets: [Which PRD sections this fuels: Problem, Users, Value Proposition, Future Work]
+   └─ Candidate IDs: [Notional CFD-/BR-/UJ- entries to create downstream]
+
+💔 **PRIMARY PAIN POINT:**
+   └─ [One workflow bottleneck quantified by time or money]
+
+📊 **DEMAND SIGNALS:**
+   ├─ Pricing Evidence: [Competitor] – $X-Y/mo – [URL]
+   ├─ Pricing Evidence: [Competitor] – $X-Y/mo – [URL]
+   └─ Market Validation: [1 sentence why the price band is accepted]
+
+👥 **COMMUNITY EVIDENCE:**
+   ├─ Primary: [Platform – Community] (≈ members, last activity date)
+   ├─ Secondary: [Platform – Community]
+   └─ Quote: "[Exact user quote ≤40 words]" – [Source link]
+
+🚀 **POTENTIAL MVP SCOPE:**
+   [2-3 sentence description of the core feature set]
+
+🧭 **ASSUMPTIONS & OPEN QUESTIONS:**
+   └─ [Bulleted list (max 3) highlighting data gaps]
+
+📦 **ARTIFACTS FOR AURA:**
+   └─ [Links and file names for pricing captures, community screenshots, and any supporting research]
+
+🪪 **READINESS NOTES:**
+   └─ [One sentence confirming the idea passes v0.1 Spark gate criteria or flagging blockers]
+
+## Research Constraints (Non-Negotiable)
+- **Competitor Pricing:** Provide at least two direct competitors with live pricing pages captured within the past 30 days.
+- **Community Activity:** Surface user complaints posted within the last 30 days. Include timestamps in the source list if not visible in the quote.
+- **Vertical Focus:** Avoid umbrella terms. If a vertical can be subdivided further (e.g., "dental labs" vs. "dental practices"), choose the more precise option.
+- **Build Scope:** Ensure the MVP can be prototyped by a 2-3 person team in ≤6 hours using standard SaaS tooling (e.g., Airtable, Retool, Zapier, simple scripts).
+- **Idea Uniqueness:** Do not reuse a vertical or pain point submitted in the same batch. Note related variants in the Assumptions section.
+
+## Quality Gates
+| Criterion | Pass Condition | Reject Condition |
+|-----------|----------------|------------------|
+| **Demand Signal** | Competitors older than 5 years or with 1k+ users | Only pre-launch or stealth competitors |
+| **Pricing Proof** | Two or more live pricing references | Pricing copied from articles or reviews |
+| **Pain Severity** | Users describe weekly disruption or measurable loss | Complaints about minor UX annoyance |
+| **Community Health** | Communities with >5 new posts in last 30 days | Dormant forums or archived threads |
+| **MVP Scope** | Afternoon build with 1-2 workflows | Requires custom ML or integrations with >3 systems |
+
+## Packaging for AURA
+- **Summary Sheet:** Begin your submission with a high-level table (Idea ID, Industry, Primary Pain Point, MVP hook) so AURA can prioritize quickly.
+- **Methodology Signal:** Include a column showing the PRD sections affected and candidate SoT IDs so the downstream agent can log work against the ID graph.
+- **File Naming:** Name evidence files using the format `[idea-id]__[artifact-type].*` (e.g., `dental-lab-qc__pricing1.png`).
+- **Traceability:** Reference file names directly in the `ARTIFACTS FOR AURA` section.
+- **Hand-off Note:** Close each idea with 1-2 sentences suggesting how AURA could frame the PRD Opportunity and High-Level Solution sections.
+- **Lifecycle Hook:** State what the next lifecycle checkpoint should be (e.g., "Ready for v0.2 Market Definition once ICP confirmed").
+
+## Platform Guidance
+- **Perplexity Space:** Create one thread per Idea ID. Upload pricing/community captures as files and tag them using `#idea-id` for quick filtering.
+- **Google Gemini / ChatGPT / Claude Projects:** Load competitor/community artifacts into the workspace before prompting. Reuse the "Core Instructions" as the system prompt and maintain separate conversation threads titled with the Idea ID.
+
+## Reporting Checklist
+Before submission, confirm:
+- [ ] 3-5 ideas, each in distinct verticals
+- [ ] All pricing links live and archived
+- [ ] Community quotes dated within 30 days
+- [ ] MVP scope describes only launch-critical workflows
+- [ ] Assumptions/Open Questions populated
+- [ ] Artifacts named and linked per convention
+- [ ] Summary Sheet provided


### PR DESCRIPTION
## Summary
- create a dedicated docs/prd/instructions hierarchy to host stage-specific PRD guidance
- relocate the v0.1 research and AURA intake guides into the new library and annotate them for reuse
- document the instruction library in the repository organization guide so future stages follow the same pattern

## Testing
- not run (documentation-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a137b19c8326bb5c0709db1a1d43)