### PR TITLE
Convert template purity standard to SOT builder skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -58,10 +58,11 @@ skills/
 ├── ghm-gate-check/                        # Methodology
 ├── ghm-id-register/                       # Methodology
 ├── ghm-status-sync/                       # Methodology
-└── ghm-harvest/                           # Methodology
+├── ghm-harvest/                           # Methodology
+└── ghm-sot-builder/                       # Methodology
 ```
 
-**29 skills total** covering the complete PRD lifecycle v0.1→v1.0.
+**30 skills total** covering the complete PRD lifecycle v0.1→v1.0.
 
 ---
 
@@ -78,7 +79,7 @@ skills/
 | **v0.7 Build**     | Epic Scoping, Test Planning, Implementation Loop                 | 3     |
 | **v0.8 Release**   | Release Planning, Runbook Creation, Monitoring Setup             | 3     |
 | **v0.9 Launch**    | GTM Strategy, Launch Metrics, Feedback Loop Setup                | 3     |
-| **Methodology**    | Gate Check, ID Register, Status Sync, Harvest                    | 4     |
+| **Methodology**    | Gate Check, ID Register, Status Sync, Harvest, SoT Builder       | 5     |
 
 See [`skills-inventory.md`](skills-inventory.md) for full specifications.
 

--- a/.claude/skills/ghm-sot-builder/SKILL.md
+++ b/.claude/skills/ghm-sot-builder/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: ghm-sot-builder
+description: >
+  Creates new Source of Truth (SoT) files when existing templates don't fit your needs.
+  Triggers on requests to create a new SoT file, add a new artifact type, or when user says
+  "I need to track [X] but there's no SoT for it", "create SoT", "new source of truth".
+  Outputs a properly structured SoT.*.md file with ID prefix, frontmatter, and update protocol.
+---
+
+# SoT Builder
+
+Create new Source of Truth files that fit your product's unique needs while maintaining template purity.
+
+## When to Use This Skill
+
+This skill is for **rare occasions** (3-4 times per product lifecycle) when:
+- You fork this repo and the existing SoT files don't cover your artifact types
+- Your product needs to track a concept that doesn't fit existing ID prefixes
+- You need to consolidate scattered documentation into a canonical SoT
+
+**Do NOT use** when:
+- An existing SoT file covers your need (just add entries there)
+- You want to track temporary/session-specific data (use `temp/` instead)
+- The artifact type is already covered by `ghm-id-register`
+
+## Workflow Overview
+
+1. **Identify Need** → Confirm no existing SoT fits
+2. **Design Schema** → Define ID prefix, categories, required fields
+3. **Draft Template** → Create pure structure (no methodology teaching)
+4. **Validate Purity** → Apply the litmus test
+5. **Register & Integrate** → Update SoT.README.md and ID system
+
+## Core Output Template
+
+See `assets/sot-template.md` for the copy-paste starter template.
+
+| Element | Definition | Required |
+|---------|------------|----------|
+| **YAML Frontmatter** | version, purpose, id_prefix, authority | Yes |
+| **Purpose Block** | Single paragraph explaining what this tracks | Yes |
+| **Navigation Section** | Category links for quick access | Yes |
+| **Entry Template** | Repeatable structure for each ID | Yes |
+| **Cross-Reference Index** | Bidirectional links to other SoT files | Yes |
+| **Update Protocol** | When/how to add new entries | Yes |
+
+## Step 1: Identify the Need
+
+Before creating a new SoT, verify:
+
+### Checklist
+- [ ] Searched existing SoT files for similar artifact types
+- [ ] Confirmed the concept is **durable** (survives multiple sessions)
+- [ ] Confirmed the concept needs **unique IDs** for cross-referencing
+- [ ] Confirmed this isn't better served by a subsection in an existing SoT
+
+### Questions to Answer
+
+1. **What artifact type does this track?**
+   - Bad: "Notes" (too generic)
+   - Good: "Partner Integration Contracts" (specific, durable)
+
+2. **Why can't existing SoT files handle this?**
+   - Valid: "We need different fields than API contracts for partner integrations"
+   - Invalid: "I just want a separate file" (preference, not need)
+
+3. **What ID prefix will you use?**
+   - Must be unique across the system
+   - 2-4 uppercase letters
+   - Check `SoT/SoT.UNIQUE_ID_SYSTEM.md` for existing prefixes
+
+## Step 2: Design the Schema
+
+Define the structure before writing:
+
+### ID Prefix Selection
+
+```
+Format: [PREFIX]-[XXX]
+Examples: PIC-001, INT-042, MIG-003
+```
+
+**Rules**:
+- 2-4 uppercase letters
+- Descriptive but short
+- Unique across all SoT files
+- Check existing prefixes in `SoT/SoT.UNIQUE_ID_SYSTEM.md`
+
+### Category Ranges
+
+Reserve ID ranges for logical groupings:
+
+```markdown
+**Category A** (XXX-001 to XXX-099):
+**Category B** (XXX-101 to XXX-199):
+**Category C** (XXX-201 to XXX-299):
+```
+
+### Required Fields per Entry
+
+Define the minimum fields every entry needs:
+
+| Field | Purpose | Example |
+|-------|---------|---------|
+| **ID** | Unique identifier | `PIC-001` |
+| **Title** | Human-readable name | "Stripe Payment Integration" |
+| **Status** | Current state | Active / Deprecated / Planned |
+| **Created** | Origin date | 2025-01-10 |
+| **Last Updated** | Last modification | 2025-01-15 |
+| **Related IDs** | Cross-references | BR-101, API-045 |
+
+### Optional Fields
+
+Add domain-specific fields as needed, but keep them structural (not methodology):
+
+- Good: "Partner Contact" (data field)
+- Bad: "Best Practices for Partner Selection" (methodology teaching)
+
+## Step 3: Draft the Template
+
+Use `assets/sot-template.md` as your starting point.
+
+### Structure Sections
+
+1. **YAML Frontmatter** - Metadata for the file
+2. **Title & Purpose Block** - What this SoT tracks
+3. **Navigation by Category** - Quick links to entries
+4. **Entry Template** - Repeatable structure (copy for each new entry)
+5. **Deprecated Section** - Where old entries go
+6. **Cross-Reference Index** - Bidirectional links
+7. **Update Protocol** - When/how to maintain
+
+### Template Purity Rules
+
+**KEEP in the template** (self-documentation):
+- When to add new entries
+- Required fields checklist
+- Cross-reference integrity checks
+- File-specific maintenance procedures
+
+**MOVE to skill references** (methodology teaching):
+- "Best practices" for this domain
+- "What makes a good entry"
+- Example workflows beyond format
+- Evaluation criteria
+
+### Litmus Test
+
+For each section, ask:
+
+> "Is this teaching me how to maintain the FILE STRUCTURE, or teaching me DOMAIN KNOWLEDGE about what makes good content?"
+
+- File structure maintenance → Keep in template
+- Domain knowledge → Move to skill references
+
+## Step 4: Validate Purity
+
+Before finalizing, run this checklist:
+
+### Purity Checklist
+- [ ] No "how to analyze" or "how to evaluate" content
+- [ ] No "best practices" or "key learnings" sections
+- [ ] No cross-file workflows (multi-file coordination)
+- [ ] No "what makes a good entry" evaluation criteria
+- [ ] Examples show FORMAT only, not instructional CONTENT
+- [ ] Self-documentation is under 20% of total file size
+
+### Self-Documentation Checklist
+- [ ] Has "Update Protocol" section
+- [ ] Documents when to add new IDs
+- [ ] Includes cross-reference integrity checks
+- [ ] Specifies required fields for new entries
+- [ ] Self-documentation is file-specific (not generic)
+
+### Context Efficiency Checklist
+- [ ] Template can be read without loading other files
+- [ ] Methodology examples are in skill references, not template
+- [ ] General governance references SoT.README.md
+
+## Step 5: Register and Integrate
+
+After creating the SoT file:
+
+### Update SoT.README.md
+
+Add entry to the structure table:
+
+```markdown
+| `SoT.{YOUR_FILE}.md` | {PREFIX}-### | {Purpose description} |
+```
+
+### Update SoT.UNIQUE_ID_SYSTEM.md
+
+Add new prefix to Section 1.2 Standard Prefixes:
+
+```markdown
+| **{PREFIX}** | {Meaning} | `SoT.{YOUR_FILE}.md` |
+```
+
+### Create Index Tables
+
+Add empty index table in Part 2 of SoT.UNIQUE_ID_SYSTEM.md:
+
+```markdown
+#### {Your Type} ({PREFIX}-XXX)
+
+| ID | Title | Status | Used By |
+|----|-------|--------|---------|
+| {PREFIX}-001 | {Title} | Active | {IDs} |
+```
+
+## Quality Gates
+
+### Pass Checklist
+- [ ] ID prefix is unique across all SoT files
+- [ ] Template follows purity standard
+- [ ] Update protocol included
+- [ ] Cross-reference index structure defined
+- [ ] SoT.README.md updated
+- [ ] SoT.UNIQUE_ID_SYSTEM.md updated
+
+### Testability Check
+- [ ] Can create a new entry using only the template instructions
+- [ ] Cross-references can be validated programmatically
+- [ ] Entries can be found by ID search
+
+## Anti-Patterns
+
+| Pattern | Example | Fix |
+|---------|---------|-----|
+| Methodology in template | "Best practices for partner selection" | Move to skill references |
+| Duplicate prefix | Using BR- for a new file | Choose unique prefix |
+| Too generic | "Notes.md" | Be specific: "Partner_Integrations.md" |
+| No update protocol | Template with no maintenance section | Add "Update Protocol" section |
+| Orphan SoT | Not registered in SoT.README.md | Always register new files |
+
+## Bundled Resources
+
+- **`references/sot-patterns.md`** — Common patterns across existing SoT files
+- **`references/examples.md`** — Before/after examples of SoT creation
+- **`assets/sot-template.md`** — Copy-paste starter template
+
+## Handoff
+
+After creating a new SoT:
+1. SoT file exists at `SoT/SoT.{NAME}.md`
+2. SoT.README.md lists the new file
+3. SoT.UNIQUE_ID_SYSTEM.md has the new prefix
+4. Ready to use `ghm-id-register` for adding entries

--- a/.claude/skills/ghm-sot-builder/assets/sot-template.md
+++ b/.claude/skills/ghm-sot-builder/assets/sot-template.md
@@ -1,0 +1,151 @@
+# SoT File Template
+
+> Copy this template when creating a new Source of Truth file.
+> Replace all `{PLACEHOLDER}` values with your specific content.
+> Delete this instruction block after copying.
+
+---
+
+```markdown
+---
+version: 1.0
+purpose: {Brief description of what this file tracks - one sentence}
+id_prefix: {PREFIX}-###
+last_updated: {YYYY-MM-DD}
+authority: This is a SoT file - IDs created here are referenced by {list files: PRD.md, EPICs, other SoT files}
+---
+
+# {Artifact Type} (SoT File)
+
+> **Purpose**: {What this file tracks - expand on frontmatter purpose}
+> **ID Prefix**: {PREFIX}-XXX
+> **Status**: Active SoT file
+> **Cross-References**: {List files that reference or are referenced by this SoT}
+
+## Navigation by Category
+
+**{Category A}** ({PREFIX}-001 to {PREFIX}-099):
+- [{PREFIX}-001](#{prefix}-001-title) - {Entry title}
+
+**{Category B}** ({PREFIX}-101 to {PREFIX}-199):
+- [{PREFIX}-101](#{prefix}-101-title) - {Entry title}
+
+**{Category C}** ({PREFIX}-201 to {PREFIX}-299):
+- [{PREFIX}-201](#{prefix}-201-title) - {Entry title}
+
+---
+
+## {PREFIX}-001: {Entry Title}
+
+**ID**: {PREFIX}-001
+**Category**: {Category Name}
+**Status**: Active | Deprecated | Planned
+**Owner**: {Team or Role}
+**Created**: {YYYY-MM-DD}
+**Last Updated**: {YYYY-MM-DD}
+
+### {Primary Content Section Name}
+
+{Main content for this entry - structure depends on artifact type}
+
+### Related IDs
+
+**{Relationship Type A}**:
+- [{OTHER-PREFIX}-XXX](SoT.OTHER_FILE.md#{anchor}) - {Description}
+
+**{Relationship Type B}**:
+- [{OTHER-PREFIX}-YYY](SoT.OTHER_FILE.md#{anchor}) - {Description}
+
+### Version History
+
+| Version | Date | Changes | Updated By |
+|---------|------|---------|------------|
+| 1.0 | {YYYY-MM-DD} | Initial creation | {Name} |
+
+---
+
+## {PREFIX}-002: {Next Entry Title}
+
+{Repeat the entry structure above for each new entry}
+
+---
+
+## Deprecated Entries
+
+### {PREFIX}-XXX: {Deprecated Entry Title} [DEPRECATED]
+
+**Status**: Deprecated ({YYYY-MM-DD})
+**Replacement**: [{PREFIX}-YYY](#{prefix}-yyy-title) | None
+**Reason**: {Why deprecated}
+**Migration Guide**: {How to transition if applicable}
+**Removal Date**: {When this can be cleaned up}
+
+---
+
+## Cross-Reference Index
+
+> **Maintenance Note**: Update manually unless you add tooling in a fork.
+
+**{PREFIX} by {Other Prefix}**:
+- {OTHER}-XXX uses: {PREFIX}-001, {PREFIX}-002
+- {OTHER}-YYY uses: {PREFIX}-001
+
+**{PREFIX} by Category**:
+- {Category A}: {PREFIX}-001, {PREFIX}-002
+- {Category B}: {PREFIX}-101
+
+---
+
+## Update Protocol
+
+### When to Add New {PREFIX}-XXX IDs
+
+1. **{Scenario A}**: {When to create this type of entry}
+2. **{Scenario B}**: {Another trigger for new entries}
+3. **{Scenario C}**: {Another trigger for new entries}
+
+### Bidirectional Reference Checklist
+
+When adding a new {PREFIX}-XXX:
+- [ ] Update {relevant SoT file} "{section}" for each {relationship}
+- [ ] Update {another SoT file} "{section}" for each {relationship}
+- [ ] Update EPIC Section 2 "Context & IDs" if part of active work
+- [ ] Update SoT.UNIQUE_ID_SYSTEM.md registry tables
+
+### Required Fields Validation
+
+Before saving a new entry, verify:
+- [ ] ID follows {PREFIX}-### format (3-digit, zero-padded)
+- [ ] Title is descriptive and unique
+- [ ] Status is set (Active/Planned/Deprecated)
+- [ ] Created date is populated
+- [ ] At least one Related ID exists (or documented reason why none)
+
+---
+
+*End of SoT.{FILENAME}.md - This SoT file is the authoritative source for all {PREFIX}-XXX IDs*
+```
+
+---
+
+## Post-Creation Checklist
+
+After creating your new SoT file using this template:
+
+1. **Register in SoT.README.md**
+   ```markdown
+   | `SoT.{YOUR_FILE}.md` | {PREFIX}-### | {Purpose} |
+   ```
+
+2. **Register prefix in SoT.UNIQUE_ID_SYSTEM.md**
+   - Add to Section 1.2 Standard Prefixes table
+   - Add empty index table in Section 2.2
+
+3. **Validate purity**
+   - [ ] No methodology teaching in template
+   - [ ] Update Protocol is file-specific
+   - [ ] Self-documentation < 20% of file
+
+4. **Test the template**
+   - Create one real entry using only the template instructions
+   - Verify cross-references resolve correctly

--- a/.claude/skills/ghm-sot-builder/references/examples.md
+++ b/.claude/skills/ghm-sot-builder/references/examples.md
@@ -1,0 +1,314 @@
+# SoT Builder Examples
+
+Real-world examples of creating new Source of Truth files.
+
+---
+
+## Example 1: Partner Integration Contracts
+
+### Scenario
+
+A B2B SaaS product needs to track third-party integrations (Stripe, Twilio, SendGrid) with their own contracts, SLAs, and API dependencies. Existing SoT files don't fit:
+
+- `SoT.API_CONTRACTS.md` — Tracks OUR APIs, not partner APIs
+- `SoT.BUSINESS_RULES.md` — Tracks rules, not integration specs
+
+### Decision Process
+
+**Q: What artifact type does this track?**
+A: Partner Integration Contracts — specs for each third-party service
+
+**Q: Why can't existing SoT files handle this?**
+A: Partner integrations need fields like "SLA", "Billing Contact", "Fallback Provider" that don't fit API or BR schemas
+
+**Q: What ID prefix will you use?**
+A: `PIC-` (Partner Integration Contract)
+
+### Schema Design
+
+```markdown
+ID Prefix: PIC-###
+
+Categories:
+- PIC-001 to PIC-099: Payment providers
+- PIC-101 to PIC-199: Communication services
+- PIC-201 to PIC-299: Infrastructure services
+
+Required Fields:
+- Partner Name
+- Contract Status (Active/Expired/Pending)
+- SLA Guarantee
+- Billing Contact
+- Fallback Provider (if any)
+- Integration APIs (links to API-XXX)
+```
+
+### Resulting SoT File Structure
+
+```markdown
+---
+version: 1.0
+purpose: Source of Truth for third-party partner integrations and their contracts
+id_prefix: PIC-###
+last_updated: 2025-01-10
+authority: This SoT defines all external service dependencies
+---
+
+# Partner Integration Contracts (SoT File)
+
+> **Purpose**: Specifications for all third-party service integrations
+> **ID Prefix**: PIC-XXX
+> **Status**: Active SoT file
+> **Cross-References**: SoT.API_CONTRACTS.md, SoT.BUSINESS_RULES.md
+
+## Navigation by Category
+
+**Payment Providers** (PIC-001 to PIC-099):
+- [PIC-001](#pic-001-stripe) - Stripe Payment Processing
+
+**Communication Services** (PIC-101 to PIC-199):
+- [PIC-101](#pic-101-twilio) - Twilio SMS/Voice
+
+---
+
+## PIC-001: Stripe Payment Processing
+
+**ID**: PIC-001
+**Partner**: Stripe, Inc.
+**Status**: Active
+**Contract Signed**: 2024-06-15
+**Renewal Date**: 2025-06-15
+**Billing Contact**: payments@ourcompany.com
+
+### SLA Guarantee
+
+- Uptime: 99.99%
+- Transaction Processing: <2 seconds
+- Support Response: 4 hours (business critical)
+
+### Integration Points
+
+**Our APIs that use this partner**:
+- [API-045](SoT.API_CONTRACTS.md#api-045) - POST /payments/charge
+- [API-046](SoT.API_CONTRACTS.md#api-046) - POST /subscriptions/create
+
+**Business Rules affected**:
+- [BR-101](SoT.BUSINESS_RULES.md#br-101) - Payment retry policy
+
+### Fallback Provider
+
+Primary: Stripe
+Fallback: None (evaluate adding Adyen)
+
+### Version History
+
+| Version | Date | Changes | Updated By |
+|---------|------|---------|------------|
+| 1.0 | 2025-01-10 | Initial creation | Product Team |
+
+---
+
+## Update Protocol
+
+### When to Add New PIC-XXX IDs
+
+1. **New Partner**: Signing contract with new service provider
+2. **Service Migration**: Moving from one provider to another
+3. **New Integration Type**: Adding partner for new capability
+
+### Bidirectional Reference Checklist
+
+When adding a new PIC-XXX:
+- [ ] Update SoT.API_CONTRACTS.md "Uses Partner" section for affected APIs
+- [ ] Update SoT.BUSINESS_RULES.md if partner affects rule enforcement
+- [ ] Update SoT.UNIQUE_ID_SYSTEM.md registry tables
+```
+
+---
+
+## Example 2: Migration Procedures
+
+### Scenario
+
+An enterprise product needs to track database migration procedures with rollback plans and dependencies. This doesn't fit existing SoT files:
+
+- `SoT.ACTUAL_SCHEMA.md` — Tracks schema state, not migration procedures
+- `SoT.deployment_playbook.md` — General deployment, not schema-specific
+
+### Decision Process
+
+**Q: What artifact type does this track?**
+A: Database migration procedures with rollback plans
+
+**Q: Why can't existing SoT files handle this?**
+A: Migrations need sequencing, dependencies, and rollback scripts that don't fit DEP- entries
+
+**Q: What ID prefix will you use?**
+A: `MIG-` (Migration)
+
+### Schema Design
+
+```markdown
+ID Prefix: MIG-###
+
+Categories:
+- MIG-001 to MIG-099: Schema migrations
+- MIG-101 to MIG-199: Data migrations
+- MIG-201 to MIG-299: Index migrations
+
+Required Fields:
+- Migration Name
+- Status (Pending/Applied/Rolled Back)
+- Dependencies (previous MIG-XXX)
+- Affected Tables (DBT-XXX)
+- Rollback Script
+- Applied Date
+```
+
+### Key Differences from Example 1
+
+This example shows a **procedural SoT** (ordered steps) vs. a **entity SoT** (static definitions):
+
+- Entry order matters (dependencies)
+- Status changes over time (Applied/Rolled Back)
+- Links to both past and future entries
+
+---
+
+## Example 3: What NOT to Create
+
+### Anti-Pattern: "Notes" SoT
+
+**Request**: "I want a SoT for random notes and ideas"
+
+**Why it fails**:
+- Not durable (notes are transient)
+- No clear ID structure
+- Doesn't need cross-referencing
+- Better served by `temp/` folder
+
+**Better approach**: Use `temp/scratch.md` for session notes, then harvest insights to `SoT.customer_feedback.md` (CFD- entries) if they become durable.
+
+### Anti-Pattern: Duplicate Coverage
+
+**Request**: "I want a SoT for authentication rules"
+
+**Why it fails**:
+- Already covered by `SoT.BUSINESS_RULES.md` (BR- entries)
+- Would fragment related information
+- Creates maintenance burden
+
+**Better approach**: Add BR-XXX entries in the "Security" category range (BR-101 to BR-199) within the existing BUSINESS_RULES file.
+
+### Anti-Pattern: Methodology in Template
+
+**Request**: "I want a SoT that includes best practices for each entry"
+
+**Why it fails**:
+- Methodology teaching belongs in skill references
+- Violates template purity standard
+- Bloats context when file is loaded
+
+**Better approach**: Keep template pure, create a skill (like `prd-vXX-{domain}`) that loads methodology when creating entries.
+
+---
+
+## Before/After: Template Contamination
+
+### BEFORE (Contaminated Template)
+
+```markdown
+## MIG-001: Add user_preferences table
+
+**ID**: MIG-001
+**Status**: Pending
+
+### Best Practices for This Migration
+
+When creating new tables:
+1. Always add created_at and updated_at columns
+2. Consider indexing foreign keys
+3. Use UUID for primary keys in distributed systems
+4. Think about partitioning for large tables...
+
+### Migration Script
+
+```sql
+CREATE TABLE user_preferences...
+```
+```
+
+**Problem**: "Best Practices" section is methodology teaching that should be in a skill reference.
+
+### AFTER (Pure Template)
+
+```markdown
+## MIG-001: Add user_preferences table
+
+**ID**: MIG-001
+**Status**: Pending
+**Created**: 2025-01-10
+**Dependencies**: None (first migration)
+**Affects Tables**: [DBT-015](SoT.ACTUAL_SCHEMA.md#dbt-015)
+
+### Migration Script
+
+```sql
+CREATE TABLE user_preferences (
+  id UUID PRIMARY KEY,
+  user_id UUID REFERENCES users(id),
+  preferences JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+### Rollback Script
+
+```sql
+DROP TABLE IF EXISTS user_preferences;
+```
+
+### Version History
+
+| Version | Date | Changes | Applied By |
+|---------|------|---------|------------|
+| 1.0 | 2025-01-10 | Initial creation | Platform Team |
+```
+
+**Fixed**: Methodology moved to skill references. Template contains only structural information.
+
+---
+
+## Registration Checklist
+
+After creating any new SoT file, complete:
+
+### SoT.README.md Update
+
+```markdown
+| `SoT.{YOUR_FILE}.md` | {PREFIX}-### | {Purpose} |
+```
+
+### SoT.UNIQUE_ID_SYSTEM.md Updates
+
+**Section 1.2 - Add prefix**:
+```markdown
+| **{PREFIX}** | {Meaning} | `SoT.{YOUR_FILE}.md` |
+```
+
+**Section 2.2 - Add index table**:
+```markdown
+#### {Your Type} ({PREFIX}-XXX)
+
+| ID | Title | Status | Used By |
+|----|-------|--------|---------|
+```
+
+### Verification
+
+- [ ] File exists at `SoT/SoT.{NAME}.md`
+- [ ] SoT.README.md lists the file
+- [ ] SoT.UNIQUE_ID_SYSTEM.md has the prefix
+- [ ] Can create a test entry using template
+- [ ] Cross-references work in both directions

--- a/.claude/skills/ghm-sot-builder/references/sot-patterns.md
+++ b/.claude/skills/ghm-sot-builder/references/sot-patterns.md
@@ -1,0 +1,294 @@
+# SoT Patterns Reference
+
+> Extracted from existing SoT files and the Template Purity Standard.
+
+This reference documents the common structural patterns found across all Source of Truth files in the GHM methodology.
+
+---
+
+## 1. YAML Frontmatter Patterns
+
+Every SoT file starts with YAML frontmatter. Two main patterns exist:
+
+### Pattern A: Simple Metadata (Governance Files)
+
+```yaml
+---
+title: "Human-readable title"
+updated: "YYYY-MM-DD"
+authority: "Source of authority"
+---
+```
+
+Used by: `SoT.UNIQUE_ID_SYSTEM.md`, `SoT.TEMPLATE_PURITY_STANDARD.md`, `SoT.README.md`
+
+### Pattern B: Full Specification (Entry-based Files)
+
+```yaml
+---
+version: 1.0
+purpose: Brief description of what this file tracks
+id_prefix: XXX-###
+last_updated: YYYY-MM-DD
+authority: This is a SoT file - IDs created here are referenced by [list files]
+---
+```
+
+Used by: `SoT.BUSINESS_RULES.md`, `SoT.USER_JOURNEYS.md`, `SoT.API_CONTRACTS.md`
+
+---
+
+## 2. Purpose Block Pattern
+
+Immediately after frontmatter, use a blockquote to state purpose:
+
+```markdown
+# {Title} (SoT File)
+
+> **Purpose**: {What this file tracks}
+> **ID Prefix**: {PREFIX}-XXX
+> **Status**: Active SoT file
+> **Cross-References**: {List of files that reference this}
+```
+
+This pattern makes the file's role immediately clear when opened.
+
+---
+
+## 3. Navigation Section Pattern
+
+After the purpose block, include a navigation section:
+
+```markdown
+## Navigation by Category
+
+**{Category A}** ({PREFIX}-001 to {PREFIX}-099):
+- [{PREFIX}-001](#{prefix}-001-name) - {Title}
+- [{PREFIX}-002](#{prefix}-002-name) - {Title}
+
+**{Category B}** ({PREFIX}-101 to {PREFIX}-199):
+- [{PREFIX}-101](#{prefix}-101-name) - {Title}
+```
+
+Benefits:
+- Quick scanning for specific entries
+- ID range indicates category at a glance
+- Anchors enable direct linking
+
+---
+
+## 4. Entry Structure Pattern
+
+Each entry follows a consistent structure:
+
+```markdown
+## {PREFIX}-XXX: {Title}
+
+**ID**: {PREFIX}-XXX
+**Category**: {Category Name}
+**Status**: Active | Deprecated | Planned
+**Owner**: {Team or Role}
+**Created**: YYYY-MM-DD
+**Last Updated**: YYYY-MM-DD
+
+### {Primary Content Section}
+
+{Main content of this entry}
+
+### Related IDs
+
+**{Relationship Type}**:
+- [{OTHER-PREFIX}-XXX](SoT.OTHER_FILE.md#{id-anchor}) - {Description}
+- [{OTHER-PREFIX}-YYY](SoT.OTHER_FILE.md#{id-anchor}) - {Description}
+
+### Version History
+
+| Version | Date | Changes | Updated By |
+|---------|------|---------|------------|
+| 1.0 | YYYY-MM-DD | Initial creation | {Name} |
+```
+
+Key principles:
+- Metadata comes first (scannable)
+- Related IDs use full markdown links for navigation
+- Version history tracks changes over time
+
+---
+
+## 5. Cross-Reference Index Pattern
+
+Near the end of the file, include a cross-reference index:
+
+```markdown
+## Cross-Reference Index
+
+> **Auto-Generated Section**: Maintain manually unless you add tooling.
+
+**{Prefix} by {Other Prefix}**:
+- {OTHER}-045 {relationship}: {PREFIX}-001, {PREFIX}-002
+- {OTHER}-046 {relationship}: {PREFIX}-001
+
+**{Prefix} by {Category}**:
+- {Category A}: {PREFIX}-001, {PREFIX}-102
+- {Category B}: {PREFIX}-002, {PREFIX}-201
+```
+
+This enables bidirectional navigation and integrity checking.
+
+---
+
+## 6. Deprecated Entries Pattern
+
+Deprecated entries go in a separate section:
+
+```markdown
+## Deprecated Entries
+
+### {PREFIX}-XXX: {Title} [DEPRECATED]
+
+**Status**: Deprecated (YYYY-MM-DD)
+**Replacement**: [{PREFIX}-YYY](#{prefix}-yyy-title) | None
+**Reason**: {Why deprecated}
+**Migration Guide**: {How to transition}
+**Removal Date**: {When this can be deleted}
+```
+
+Key rules:
+- Never delete IDs, only deprecate
+- Always link to replacement if one exists
+- Include migration guidance
+
+---
+
+## 7. Update Protocol Pattern
+
+Every SoT file ends with an update protocol:
+
+```markdown
+## Update Protocol
+
+### When to Add New {PREFIX}-XXX IDs
+
+1. **{Scenario A}**: {Description}
+2. **{Scenario B}**: {Description}
+3. **{Scenario C}**: {Description}
+
+### Bidirectional Reference Checklist
+
+When adding a new {PREFIX}-XXX:
+- [ ] Update {OTHER_FILE}.md "Used By" section
+- [ ] Update {ANOTHER_FILE}.md "Related" section
+- [ ] Update EPIC Section 2 "Context & IDs"
+- [ ] Update SoT.UNIQUE_ID_SYSTEM.md registry tables
+```
+
+This is **template self-documentation** (keep in file), not methodology teaching (move to skills).
+
+---
+
+## 8. File Naming Pattern
+
+```
+SoT.{ARTIFACT_TYPE}.md
+```
+
+Examples:
+- `SoT.BUSINESS_RULES.md` (uppercase for emphasis)
+- `SoT.customer_feedback.md` (lowercase also acceptable)
+- `SoT.DESIGN_BRIEF.md`
+
+Conventions:
+- Always start with `SoT.`
+- Use descriptive artifact type name
+- Use `.md` extension
+- Prefer uppercase for primary SoT files
+
+---
+
+## 9. ID Prefix Patterns
+
+### Standard Prefixes (Already Defined)
+
+| Prefix | Domain | Notes |
+|--------|--------|-------|
+| BR- | Business Rules | Commercial constraints |
+| UJ- | User Journeys | User flows |
+| API- | API Contracts | Endpoint definitions |
+| DBT- | Data Schema | Database tables |
+| CFD- | Customer Feedback | Insights from users |
+| DES- | Design | UI components |
+| TEST- | Tests | Validation specs |
+| DEP- | Deployment | Release steps |
+| GTM- | Go-to-Market | Launch activities |
+| RUN- | Runbooks | Operational procedures |
+| MON- | Monitoring | Observability |
+| KPI- | Metrics | Key indicators |
+
+### Creating New Prefixes
+
+When existing prefixes don't fit:
+
+1. **Check for overlap** — Could this be a category within an existing prefix?
+2. **Choose 2-4 letters** — Short but descriptive
+3. **Verify uniqueness** — Check `SoT.UNIQUE_ID_SYSTEM.md`
+4. **Register immediately** — Add to ID system file
+
+Examples of valid new prefixes:
+- `PIC-` for Partner Integration Contracts
+- `MIG-` for Migration Procedures
+- `SEC-` for Security Controls
+
+---
+
+## 10. Category Range Pattern
+
+Reserve ID ranges for logical groupings:
+
+```
+001-099: Core/Primary entries
+101-199: Secondary/Feature-specific
+201-299: Admin/Internal
+301-399: Edge cases/Exceptions
+401-499: Performance/Limits
+```
+
+This convention allows:
+- Guessing category from ID number
+- Parallel work without collision
+- Logical grouping in navigation
+
+---
+
+## 11. Template Purity Litmus Test
+
+When adding content to a SoT template, ask:
+
+> "Is this teaching me how to maintain the FILE STRUCTURE, or teaching me DOMAIN KNOWLEDGE about what makes good content?"
+
+### KEEP in Template (File Structure)
+
+- Update protocols (when/how to modify)
+- ID numbering conventions
+- Cross-reference integrity checks
+- Required fields checklist
+- File-specific maintenance procedures
+
+### MOVE to Skill References (Domain Knowledge)
+
+- "Key learnings" or "best practices"
+- Evaluation criteria (what makes good content)
+- Example workflows or prompts
+- Cross-file coordination instructions
+- Good/bad pattern examples
+
+---
+
+## 12. Context Efficiency Rule
+
+If content is only useful when THIS template is active → Keep in template (just-in-time)
+If content is useful when CREATING content for this template → Move to skill references (skill-loaded)
+
+This ensures:
+- Templates remain lean for quick loading
+- Skills load methodology only when needed
+- Context window isn't bloated with unused content

--- a/.claude/skills/skills-inventory.md
+++ b/.claude/skills/skills-inventory.md
@@ -32,6 +32,7 @@
 | **v0.9 Launch** | [GTM Strategy](#skill-gtm-strategy) | ✅ Ready | [`prd-v09-gtm-strategy/`](prd-v09-gtm-strategy/) |
 | **v0.9 Launch** | [Launch Metrics](#skill-launch-metrics) | ✅ Ready | [`prd-v09-launch-metrics/`](prd-v09-launch-metrics/) |
 | **v0.9 Launch** | [Feedback Loop Setup](#skill-feedback-loop-setup) | ✅ Ready | [`prd-v09-feedback-loop-setup/`](prd-v09-feedback-loop-setup/) |
+| **Methodology** | [SoT Builder](#skill-sot-builder) | ✅ Ready | [`ghm-sot-builder/`](ghm-sot-builder/) |
 
 **Legend:** ✅ Ready = SKILL.md complete | 📋 Spec = specification below, needs implementation
 
@@ -1943,6 +1944,78 @@ Resolution: Outcome, Date, Follow-up
 | v0.9 | GTM Strategy | GTM- (go-to-market items) |
 | v0.9 | Launch Metrics | KPI- (launch metrics) |
 | v0.9 | Feedback Loop Setup | CFD- (post-launch feedback) |
+
+---
+
+### SKILL: SoT Builder
+
+```yaml
+name: ghm-sot-builder
+stage: Methodology
+status: ready
+folder: ghm-sot-builder/
+triggers: "create SoT", "new source of truth", "I need to track [X] but there's no SoT for it", "create new SoT file", "add artifact type"
+id_outputs: []  # Creates new SoT files, not IDs
+```
+
+**Purpose:** Create new Source of Truth files when existing templates don't fit your product's unique needs.
+
+**Position in workflow:** Used ad-hoc when forking the repo or when a new artifact type emerges (rare: 3-4 times per product lifecycle).
+
+**When to Use:**
+- Forking repo and existing SoT files don't cover your artifact types
+- Product needs to track a concept that doesn't fit existing ID prefixes
+- Need to consolidate scattered documentation into a canonical SoT
+
+**When NOT to Use:**
+- An existing SoT file covers your need (just add entries there)
+- You want to track temporary/session-specific data (use `temp/` instead)
+- The artifact type is already covered by `ghm-id-register`
+
+**Execution:**
+1. Confirm no existing SoT fits the need
+2. Design schema (ID prefix, categories, required fields)
+3. Draft template using `assets/sot-template.md`
+4. Validate template purity (no methodology teaching)
+5. Register in SoT.README.md and SoT.UNIQUE_ID_SYSTEM.md
+
+**Core Output:**
+A new `SoT/SoT.{NAME}.md` file with:
+- YAML frontmatter (version, purpose, id_prefix, authority)
+- Purpose block
+- Navigation by category
+- Entry template structure
+- Cross-reference index
+- Update protocol
+
+**Template Purity Litmus Test:**
+> "Is this teaching me how to maintain the FILE STRUCTURE, or teaching me DOMAIN KNOWLEDGE about what makes good content?"
+- File structure maintenance → Keep in template
+- Domain knowledge → Move to skill references
+
+**Quality Gates:**
+- [ ] ID prefix is unique across all SoT files
+- [ ] Template follows purity standard (no methodology teaching)
+- [ ] Update protocol included
+- [ ] Cross-reference index structure defined
+- [ ] SoT.README.md updated
+- [ ] SoT.UNIQUE_ID_SYSTEM.md updated
+
+**Anti-Patterns:**
+| Pattern | Signal | Fix |
+|---------|--------|-----|
+| Methodology in template | "Best practices for X" | Move to skill references |
+| Duplicate prefix | Using BR- for a new file | Choose unique prefix |
+| Too generic | "Notes.md" | Be specific: "Partner_Integrations.md" |
+| No update protocol | Template without maintenance section | Add "Update Protocol" section |
+| Orphan SoT | Not registered in SoT.README.md | Always register new files |
+
+**Downstream Connections:**
+| Consumer | What It Uses | Example |
+|----------|--------------|---------|
+| **ghm-id-register** | New SoT file for adding entries | Use new PIC- prefix |
+| **All PRD skills** | New IDs available for cross-referencing | FEA-001 → PIC-001 |
+| **SoT.UNIQUE_ID_SYSTEM.md** | New prefix in registry | PIC- added to prefixes |
 
 ---
 


### PR DESCRIPTION
Repurposes the Template Purity Standard as a skill that helps create new SoT files when forking the repo or when existing templates don't fit unique product needs.

Skill includes:
- SKILL.md with 5-step workflow and quality gates
- references/sot-patterns.md documenting common SoT patterns
- references/examples.md with real-world examples
- assets/sot-template.md for copy-paste new SoT creation

Updates skills README.md and skills-inventory.md to include the new methodology skill (30 total skills now).