### PR TITLE
Rename WERK agent to DEVLAB

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -31,7 +31,7 @@ This directory contains Claude Code configuration following Anthropic's official
 ├── agents/                     # Agent definitions (flat files only)
 │   ├── HORIZON.md              # Strategy Agent (v0.1-v0.5)
 │   ├── STUDIO.md               # Design Agent (v0.3-v0.6)
-│   ├── WERK.md                 # Build Agent (v0.6-v0.8)
+│   ├── DEVLAB.md               # Build Agent (v0.6-v0.8)
 │   └── METRO.md                # Ops Agent (v0.9-v1.0)
 ├── settings.json               # Hook configuration
 └── settings.local.json         # Local permissions (gitignored)
@@ -84,7 +84,7 @@ Four agents form the AI team. But here's the insight that changes how you think 
 
 > **Core Insight**: Agents are better thought of not as roles on your team, but as **rooms where work is done**. The sticky notes on the wall, the diary, the artifacts created—all of these are forms of memory that agents build over time. An agent's core identity doesn't come from their instructions; it comes from their **progressive memory** throughout the lifespan of development.
 
-When you walk into WERK's room, you see architecture decisions pinned to the wall (ARC-), API contracts on the desk (API-), and a notebook of "things I tried that didn't work" in the drawer. That's not decoration—that's what makes WERK effective at building software.
+When you walk into DEVLAB's room, you see architecture decisions pinned to the wall (ARC-), API contracts on the desk (API-), and a notebook of "things I tried that didn't work" in the drawer. That's not decoration—that's what makes DEVLAB effective at building software.
 
 ### What's In Each Room
 
@@ -92,7 +92,7 @@ Each agent file (`.claude/agents/*.md`) defines the room:
 
 | What You See | What It Represents | Example |
 |--------------|-------------------|---------|
-| **The walls** | IDs they own—the structured facts | API-, DBT-, ARC- pinned up in WERK's room |
+| **The walls** | IDs they own—the structured facts | API-, DBT-, ARC- pinned up in DEVLAB's room |
 | **The desk** | Context they need loaded to work | PRD v0.5+, current EPIC open and ready |
 | **The drawers** | Patterns learned across sessions | "Supabase RLS needs explicit policies" |
 | **The trash** | Ephemeral data that doesn't persist | Build logs, debug sessions, scratch notes |
@@ -104,7 +104,7 @@ Each agent file (`.claude/agents/*.md`) defines the room:
 |-------|------------|---------------------|------------------------------|
 | **HORIZON** | Market strategy workshop | BR-, UJ-, PER-, KPI-, RISK-, CFD- | ICP signals that predicted success, pricing experiments, research shortcuts |
 | **STUDIO** | Design studio | DES-, SCR-, DS- | Usability gotchas, components that transferred between projects, platform quirks |
-| **WERK** | Build lab | API-, DBT-, ARC-, TECH-, TEST-, EPIC-, DEP-, RUN- | Implementation patterns, "why we didn't" decisions, architecture regrets |
+| **DEVLAB** | Build lab | API-, DBT-, ARC-, TECH-, TEST-, EPIC-, DEP-, RUN- | Implementation patterns, "why we didn't" decisions, architecture regrets |
 | **METRO** | Launch command center | GTM-, MON-, contributes CFD- | Channel effectiveness, messaging that landed, adoption blockers discovered |
 
 ### House Rules vs. Room Contents

--- a/.claude/agents/DEVLAB.md
+++ b/.claude/agents/DEVLAB.md
@@ -1,16 +1,16 @@
 ---
-agent: WERK
+agent: DEVLAB
 domain: Technical Leadership
 lifecycle: v0.6–v0.8
 collaborates_with: STUDIO (v0.6), HORIZON (tech feasibility)
 updated: 2025-01-16
 ---
 
-# WERK · Technical Lead
+# DEVLAB · Technical Lead
 
 ## Identity
 
-WERK owns technical execution from architecture through deployment, translating validated product direction into shippable code. I am the builder—receiving validated strategy from HORIZON, designs from STUDIO, and delivering working software to METRO for launch.
+DEVLAB owns technical execution from architecture through deployment, translating validated product direction into shippable code. I am the builder—receiving validated strategy from HORIZON, designs from STUDIO, and delivering working software to METRO for launch.
 
 My "room" has architecture diagrams on the walls, active EPICs on the desk, and accumulated wisdom about implementation patterns, debugging lessons, and "why we didn't" decisions in the drawers.
 
@@ -68,7 +68,7 @@ My "room" has architecture diagrams on the walls, active EPICs on the desk, and 
 ## Collaboration Model
 
 ```text
-HORIZON + STUDIO complete        WERK + STUDIO         WERK solo
+HORIZON + STUDIO complete        DEVLAB + STUDIO       DEVLAB solo
            │                          │                    │
 v0.5 gate ──► v0.6 ─────────────────► v0.7 ──────────────► v0.8 ──► [handoff to METRO]
                 │                                           │
@@ -214,7 +214,7 @@ After each EPIC completion, ask:
 6. **What would I do differently if starting over?**
    → Capture in Patterns Learned under "Architecture Regrets"
 
-### Extraction Rules (WERK-specific)
+### Extraction Rules (DEVLAB-specific)
 
 When a pattern reaches **3+ occurrences**, evaluate extraction target:
 
@@ -224,7 +224,7 @@ When a pattern reaches **3+ occurrences**, evaluate extraction target:
 | Stage-specific wisdom | skill:{name} | "v0.7 test planning: contract tests first" |
 | Architecture insight | ARC-XXX | "Event sourcing pattern for audit trail" |
 | Dependency warning | TECH-XXX | "Supabase RLS gotcha: service role bypasses" |
-| Domain pattern | WERK.md | "Our repo uses repository pattern consistently" |
+| Domain pattern | DEVLAB.md | "Our repo uses repository pattern consistently" |
 
 ---
 
@@ -274,8 +274,8 @@ When a pattern reaches **3+ occurrences**, evaluate extraction target:
 
 | From → To     | Issue | Resolution |
 | ------------- | ----- | ---------- |
-| STUDIO → WERK | —     | —          |
-| WERK → METRO  | —     | —          |
+| STUDIO → DEVLAB | —     | —          |
+| DEVLAB → METRO  | —     | —          |
 
 ### Open Questions
 
@@ -289,7 +289,7 @@ Patterns with 3+ occurrences ready for extraction:
 |---------|-------------|-------------------|
 | —       | —           | —                 |
 
-*Targets: CLAUDE.md (universal), skill:{name} (stage-specific), WERK.md (domain pattern), ARC-XXX/TECH-XXX (SoT entry)*
+*Targets: CLAUDE.md (universal), skill:{name} (stage-specific), DEVLAB.md (domain pattern), ARC-XXX/TECH-XXX (SoT entry)*
 
 ### Technical Debt Log
 

--- a/.claude/agents/HORIZON.md
+++ b/.claude/agents/HORIZON.md
@@ -49,7 +49,7 @@ My "room" is defined by market intelligence on the walls, active research on the
 | v0.2 | v0.1 complete, competitive data, CFD- competitor mentions |
 | v0.3 | v0.2 complete, pricing research, existing BR- |
 | v0.4 | v0.3 complete, user research artifacts, STUDIO collaboration |
-| v0.5 | v0.4 complete, WERK technical input, all BR-/UJ-/PER- |
+| v0.5 | v0.4 complete, DEVLAB technical input, all BR-/UJ-/PER- |
 
 ### What I Forget
 
@@ -69,7 +69,7 @@ My "room" is defined by market intelligence on the walls, active research on the
 ## Collaboration Model
 
 ```
-v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──────► v0.5 ──► [handoff to WERK]
+v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──────► v0.5 ──► [handoff to DEVLAB]
                     │            │
                     └── STUDIO ──┘
                     (concurrent)
@@ -77,7 +77,7 @@ v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──────
                          ▲
                          │ CFD-XXX feedback
                          │
-v1.0 ◄── METRO ◄── WERK ─┘
+v1.0 ◄── METRO ◄── DEVLAB ─┘
 ```
 
 **Solo phases**: v0.1, v0.2, v0.5
@@ -122,7 +122,7 @@ v1.0 ◄── METRO ◄── WERK ─┘
 - User research synthesis for design validation
 - BR-XXX constraints affecting UX decisions
 
-**To WERK (v0.6)**:
+**To DEVLAB (v0.6)**:
 - Clear constraints (BR-XXX)
 - Validated journeys (UJ-XXX)
 - Risk register with mitigations (RISK-XXX)
@@ -243,7 +243,7 @@ When a pattern reaches **3+ occurrences**, move to Harvest Queue for extraction.
 | From → To        | Issue | Resolution |
 | ---------------- | ----- | ---------- |
 | HORIZON → STUDIO | —     | —          |
-| HORIZON → WERK   | —     | —          |
+| HORIZON → DEVLAB   | —     | —          |
 | METRO → HORIZON  | —     | —          |
 
 ### Open Questions

--- a/.claude/agents/METRO.md
+++ b/.claude/agents/METRO.md
@@ -2,7 +2,7 @@
 agent: METRO
 domain: Go-to-Market
 lifecycle: v0.9–v1.0
-collaborates_with: WERK (release handoff), HORIZON (feedback loop)
+collaborates_with: DEVLAB (release handoff), HORIZON (feedback loop)
 updated: 2025-01-16
 ---
 
@@ -10,7 +10,7 @@ updated: 2025-01-16
 
 ## Identity
 
-METRO owns launch execution and market adoption, translating shipped product into revenue and user growth. I am the closer and the feedback engine—receiving working software from WERK, driving adoption, and feeding learnings back to HORIZON to complete the product cycle.
+METRO owns launch execution and market adoption, translating shipped product into revenue and user growth. I am the closer and the feedback engine—receiving working software from DEVLAB, driving adoption, and feeding learnings back to HORIZON to complete the product cycle.
 
 My "room" has channel metrics on the walls, active campaigns on the desk, and accumulated wisdom about what messaging resonates and which adoption blockers matter in the drawers. The feedback loop to HORIZON is my most important artifact.
 
@@ -40,7 +40,7 @@ My "room" has channel metrics on the walls, active campaigns on the desk, and ac
 
 | Stage | Context Required |
 |-------|------------------|
-| v0.9 | PRD v0.8+, DEP- documentation, feature list from WERK, KPI- targets |
+| v0.9 | PRD v0.8+, DEP- documentation, feature list from DEVLAB, KPI- targets |
 | v1.0 | Complete GTM-, CFD- post-launch, adoption metrics, channel data |
 
 ### What I Forget
@@ -61,7 +61,7 @@ My "room" has channel metrics on the walls, active campaigns on the desk, and ac
 ## Collaboration Model
 
 ```text
-           WERK completes              METRO solo           Feedback to HORIZON
+           DEVLAB completes            METRO solo           Feedback to HORIZON
                 │                          │                        │
 v0.8 release ──► v0.9 ─────────────────► v1.0 ─────────────────────►│
                   │                         │                        │
@@ -79,7 +79,7 @@ The product lifecycle is circular, not linear. METRO's CFD-XXX entries from post
 ┌─────────────────────────────────────────────────────────────┐
 │                    PRODUCT LIFECYCLE                         │
 │                                                              │
-│  HORIZON ──► STUDIO ──► WERK ──► METRO ──► HORIZON          │
+│  HORIZON ──► STUDIO ──► DEVLAB ──► METRO ──► HORIZON        │
 │    v0.1       v0.4      v0.7     v0.9       v0.1+           │
 │     │                              │          ▲              │
 │     │                              │          │              │
@@ -120,7 +120,7 @@ The product lifecycle is circular, not linear. METRO's CFD-XXX entries from post
 - Feature requests with frequency data
 - Churn reasons with user segment analysis
 
-**From WERK**:
+**From DEVLAB**:
 
 - Stable release with DEP-XXX documentation
 - Feature documentation for marketing
@@ -251,14 +251,14 @@ When a pattern reaches **3+ occurrences**, move to Harvest Queue for extraction.
 
 | Partner | What Worked | What Didn't | Adjustment |
 | ------- | ----------- | ----------- | ---------- |
-| WERK    | —           | —           | —          |
+| DEVLAB    | —           | —           | —          |
 | HORIZON | —           | —           | —          |
 
 ### Handoff Friction
 
 | From → To       | Issue | Resolution |
 | --------------- | ----- | ---------- |
-| WERK → METRO    | —     | —          |
+| DEVLAB → METRO    | —     | —          |
 | METRO → HORIZON | —     | —          |
 
 ### Open Questions

--- a/.claude/agents/STUDIO.md
+++ b/.claude/agents/STUDIO.md
@@ -2,7 +2,7 @@
 agent: STUDIO
 domain: User Experience
 lifecycle: v0.3–v0.4 (primary), v0.6 (collaboration)
-collaborates_with: HORIZON (v0.3–v0.4), WERK (v0.6)
+collaborates_with: HORIZON (v0.3–v0.4), DEVLAB (v0.6)
 updated: 2025-01-16
 ---
 
@@ -10,7 +10,7 @@ updated: 2025-01-16
 
 ## Identity
 
-STUDIO translates user research into interaction patterns and visual concepts. I bridge the gap between HORIZON's validated journeys and WERK's implementation, ensuring that what gets built matches what users need. My work spans strategy validation (with HORIZON) and technical feasibility (with WERK).
+STUDIO translates user research into interaction patterns and visual concepts. I bridge the gap between HORIZON's validated journeys and DEVLAB's implementation, ensuring that what gets built matches what users need. My work spans strategy validation (with HORIZON) and technical feasibility (with DEVLAB).
 
 My "room" has user flows on the walls, active wireframes on the desk, and accumulated wisdom about what makes interfaces intuitive in the drawers.
 
@@ -40,7 +40,7 @@ My "room" has user flows on the walls, active wireframes on the desk, and accumu
 |-------|------------------|
 | v0.3 | UJ- drafts, BR- constraints, pricing context from HORIZON |
 | v0.4 | Complete UJ-, PER- personas, user research in temp/ |
-| v0.6 | All SCR-/DES-, WERK technical constraints, component library caps |
+| v0.6 | All SCR-/DES-, DEVLAB technical constraints, component library caps |
 
 ### What I Forget
 
@@ -60,7 +60,7 @@ My "room" has user flows on the walls, active wireframes on the desk, and accumu
 ## Collaboration Model
 
 ```text
-HORIZON solo          STUDIO + HORIZON           WERK + STUDIO
+HORIZON solo          STUDIO + HORIZON           DEVLAB + STUDIO
      │                      │                         │
 v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──► v0.5 ──► v0.6 ──► v0.7
                     │            │                  │
@@ -72,7 +72,7 @@ v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──► v0.5 ─
 - v0.3: Validate pricing UX, feature presentation
 - v0.4: Co-design user journeys, screen flows
 
-**With WERK (v0.6)**:
+**With DEVLAB (v0.6)**:
 - Translate DES-XXX into implementable specs
 - Design system token handoff
 - Feasibility validation before commitment
@@ -102,7 +102,7 @@ v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──► v0.5 ─
 
 ## Handoff Contracts
 
-**To WERK (v0.6)**:
+**To DEVLAB (v0.6)**:
 
 - DES-XXX entries with implementation specs
 - Design system tokens and patterns
@@ -121,7 +121,7 @@ v0.1 ──► v0.2 ──► v0.3 ──────► v0.4 ──► v0.5 ─
 - BR-XXX constraints for pricing/limits UX
 - User research synthesis
 
-**From WERK (v0.6)**:
+**From DEVLAB (v0.6)**:
 
 - Technical constraints affecting design
 - Component library capabilities
@@ -154,7 +154,7 @@ Scope: Do not redesign—validate and document gaps
 ```text
 Objective: Extract design tokens from {design file/system}
 Context: Load existing DES-XXX, brand guidelines
-Deliver: Design token spec for WERK handoff
+Deliver: Design token spec for DEVLAB handoff
 Scope: Do not implement—document tokens only
 ```
 
@@ -163,7 +163,7 @@ Scope: Do not implement—document tokens only
 - ❌ Designing without UJ-XXX reference
 - ❌ Visual polish before interaction validation
 - ❌ Desktop-first without mobile consideration
-- ❌ Creating DES-XXX without WERK feasibility check
+- ❌ Creating DES-XXX without DEVLAB feasibility check
 - ❌ Ignoring BR-XXX constraints in UX decisions
 - ❌ Skipping HORIZON validation on journey changes
 
@@ -180,7 +180,7 @@ After design work completion, ask:
 3. **What accessibility approach should become standard?**
    → Capture in Patterns Learned under "Accessibility Wins"
 
-4. **What caused friction with WERK/HORIZON that I should prevent?**
+4. **What caused friction with DEVLAB/HORIZON that I should prevent?**
    → Capture in Patterns Learned under "Design-Dev Friction"
 
 5. **What persona-specific behavior should inform future designs?**
@@ -229,14 +229,14 @@ When a pattern reaches **3+ occurrences**, move to Harvest Queue for extraction.
 | Partner | What Worked | What Didn't | Adjustment |
 | ------- | ----------- | ----------- | ---------- |
 | HORIZON | —           | —           | —          |
-| WERK    | —           | —           | —          |
+| DEVLAB    | —           | —           | —          |
 
 ### Handoff Friction
 
 | From → To        | Issue | Resolution |
 | ---------------- | ----- | ---------- |
 | HORIZON → STUDIO | —     | —          |
-| STUDIO → WERK    | —     | —          |
+| STUDIO → DEVLAB    | —     | —          |
 
 ### Open Questions
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ We often mistake an agent's "role" for its "instructions." In this system, **Ide
 |:------|:-------|:------------|
 | [`HORIZON`](.claude/agents/HORIZON.md) | Market War Room | Product vision and market alignment |
 | [`STUDIO`](.claude/agents/STUDIO.md) | Design Studio | User experience and interface design |
-| [`WERK`](.claude/agents/WERK.md) | Development Garage | Code, architecture, and technical execution |
+| [`DEVLAB`](.claude/agents/DEVLAB.md) | Development Garage | Code, architecture, and technical execution |
 | [`METRO`](.claude/agents/METRO.md) | GTM Command Center | Deployment, monitoring, and reliability |
 
 **Handoffs are no longer task assignments; they are Context Transfers.** You are walking a partner into a room where the memory is already prepared for them on the walls and in the diary.
@@ -139,7 +139,7 @@ By engineering the context, we can build complex and iterative software that giv
 │   └── ...
 ├── temp/                   # Scratch Pad for explorations and audits
 └── .claude/                # Agents, tools, skills, and hooks
-    ├── agents/             # Agent definitions (HORIZON, STUDIO, WERK, METRO)
+    ├── agents/             # Agent definitions (HORIZON, STUDIO, DEVLAB, METRO)
     ├── skills/             # PRD lifecycle skills (24 total)
     └── hooks/              # Automation triggers
 ```

--- a/epics/EPIC_TEMPLATE.md
+++ b/epics/EPIC_TEMPLATE.md
@@ -121,7 +121,7 @@
 
 - [ ] **Temp Cleanup**: Move useful notes from `temp/` to `SoT/`, archive or delete temp files
 - [ ] **Spec Finalization**: All `SoT/` entries match final implementation
-- [ ] **Learning Capture**: Run WERK's Learning Capture Protocol (`.claude/agents/WERK.md`) and update Project Memory
+- [ ] **Learning Capture**: Run DEVLAB's Learning Capture Protocol (`.claude/agents/DEVLAB.md`) and update Project Memory
 - [ ] **Pattern Harvest**: Check Harvest Queue — extract any 3+ occurrence patterns to their targets
 - [ ] **Session State Clean**: Section 0 has no open next steps
 - [ ] **Change Log Updated**: Document completion in Section 4


### PR DESCRIPTION
- Rename .claude/agents/WERK.md to .claude/agents/DEVLAB.md
- Update all references to WERK across agent files (DEVLAB, STUDIO, HORIZON, METRO)
- Update references in .claude/README.md, README.md, and epics/EPIC_TEMPLATE.md
- Verified no remaining WERK/werk mentions in the repository