### PR TITLE
Add ENV identifier to Technical Decisions document

### DIFF
--- a/.claude/skills/prd-v06-environment-setup/SKILL.md
+++ b/.claude/skills/prd-v06-environment-setup/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: prd-v06-environment-setup
+description: Document development environment requirements for team consistency and AI agent understanding during PRD v0.6 Architecture. Triggers on requests to define environment setup, document tooling, create dev setup guide, or when user asks "what tools do I need?", "environment setup", "dev environment", "CLI requirements", "project setup", "onboarding setup". Consumes TECH- (stack selections), ARC- (architecture decisions). Outputs ENV- entries for development, CI/CD, and infrastructure environments. Feeds v0.7 Build Execution.
+---
+
+# Environment Setup
+
+Position in workflow: v0.6 Architecture Design / Technical Specification → **v0.6 Environment Setup** → v0.7 Build Execution
+
+Environment setup documents the **tools, packages, and configurations** developers need to work on the project. This eliminates environment drift and speeds up onboarding.
+
+## Environment Types
+
+| Type | What It Defines | When Required |
+|------|-----------------|---------------|
+| **ENV-001** | Development environment (local setup) | Always |
+| **ENV-002** | CI/CD pipeline configuration | When using automated testing/deployment |
+| **ENV-003** | Production infrastructure | When deploying to production |
+
+**Rule**: ENV-001 (Development Environment) is required for every project. ENV-002 and ENV-003 are optional based on project needs.
+
+## Design Principles
+
+### 1. Prefer CLIs Over MCPs
+
+**Rule**: Use CLIs for operations, MCPs only when CLIs are insufficient.
+
+| Factor | CLI | MCP |
+|--------|-----|-----|
+| Works in CI/CD | Yes | No |
+| Works locally | Yes | Yes (limited contexts) |
+| Structured output | JSON, exit codes | Varies |
+| Debugging | Standard tools | Harder |
+
+**Decision**: Default to CLI. Only document MCPs for operations where CLIs don't exist.
+
+### 2. Per-Project Over Global
+
+**Rule**: Language-specific packages installed per-project, not globally.
+
+**Global (OK):**
+- Version managers (mise, asdf, nvm)
+- System tools (jq, ripgrep)
+- Platform CLIs (gh, aws-cli)
+
+**Per-Project (Required):**
+- Linters/formatters (eslint, prettier)
+- Type checkers (typescript)
+- Testing frameworks (jest, pytest)
+
+### 3. Structured Over Prose
+
+**Rule**: ENV- specs use structured data (tables, code blocks), not narrative.
+
+**Why**:
+- AI agents can parse and execute
+- Humans can scan quickly
+- Diff-friendly in version control
+
+### 4. Verification Required
+
+**Rule**: Every ENV- spec includes verification commands.
+
+**Why**:
+- Confirms setup succeeded
+- Debugging aid
+- Onboarding confidence
+
+## Setup Process
+
+1. **Pull TECH- decisions** — What technologies are we using?
+2. **Pull ARC- decisions** — What architecture patterns apply?
+3. **Inventory tooling needs** — What do developers need installed?
+4. **Categorize by scope** — Global vs per-project
+5. **Define configuration files** — What configs are needed?
+6. **Create verification steps** — How to confirm setup works?
+7. **Document in ENV- entries** — Record in SoT.TECHNICAL_DECISIONS.md
+
+## ENV-001 Output Template (Development Environment)
+
+```
+ENV-001: Development Environment
+Category: Development Setup
+Status: Approved | Date: YYYY-MM-DD
+Owner: {Team/Person}
+
+Purpose:
+Document local development requirements for team consistency.
+
+CLIs (Global):
+- {tool}: {purpose} — {install command}
+
+Packages (Per-Project):
+- {package}: {purpose}
+
+Configuration Files:
+| File | Purpose |
+|------|---------|
+| {file} | {purpose} |
+
+Scripts:
+{
+  "validate": "{quality check command}",
+  "fix": "{auto-fix command}",
+  "test": "{test command}"
+}
+
+Verification:
+# 1. Check tools
+{tool} --version
+
+# 2. Check packages
+{package manager list command}
+
+# 3. Run validation
+npm run validate
+
+Related IDs: TECH-XXX, ARC-XXX
+```
+
+## ENV-002 Output Template (CI/CD Pipeline)
+
+```
+ENV-002: CI/CD Pipeline
+Category: Automation
+Status: Approved | Date: YYYY-MM-DD
+
+Purpose:
+Document automated testing and deployment configuration.
+
+Workflow Files:
+- {path}: {purpose}
+
+Required Secrets:
+| Secret | Purpose | Where to Set |
+|--------|---------|--------------|
+| {name} | {purpose} | {location} |
+
+Pipeline Stages:
+1. {Stage}: {What happens}
+2. {Stage}: {What happens}
+
+Related IDs: ENV-001, DEP-XXX
+```
+
+## ENV-003 Output Template (Production Infrastructure)
+
+```
+ENV-003: Production Infrastructure
+Category: Infrastructure
+Status: Approved | Date: YYYY-MM-DD
+
+Purpose:
+Document production hosting and services configuration.
+
+Hosting Platform:
+{Platform and configuration details}
+
+Environment Variables:
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| {name} | {purpose} | {yes/no} |
+
+Services:
+| Service | Purpose | Connection |
+|---------|---------|------------|
+| {service} | {purpose} | {how connected} |
+
+Related IDs: DEP-XXX, MON-XXX
+```
+
+## Common Tool Categories
+
+### Version/Environment Managers
+- `mise`, `asdf`, `nvm`, `pyenv`, `rbenv`
+- **Purpose**: Manage language versions per-project
+
+### Code Quality
+- **JavaScript/TypeScript**: `eslint`, `prettier`, `biome`
+- **Python**: `ruff`, `black`, `pylint`
+- **Go**: `golangci-lint`
+
+### Type Checking
+- **JavaScript/TypeScript**: `typescript`
+- **Python**: `mypy`, `pyright`
+
+### Data Processing
+- `jq` (JSON), `yq` (YAML)
+
+### API Testing
+- `httpie`, `curl`, `bruno-cli`
+
+### Git Workflows
+- `gh` (GitHub CLI), `glab` (GitLab CLI)
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Signal | Fix |
+|--------------|--------|-----|
+| **Global package pollution** | `npm install -g` for project packages | Use devDependencies |
+| **Missing verification** | No way to confirm setup | Add verification commands |
+| **Prose instead of structure** | Long paragraphs describing setup | Use tables and code blocks |
+| **MCP over CLI** | Using MCP when CLI exists | Prefer CLI for portability |
+| **Undocumented config** | Config files without explanation | Document purpose of each file |
+| **Implicit dependencies** | Setup fails without warning | List all dependencies explicitly |
+
+## Quality Gates
+
+Before proceeding to Build Execution:
+
+- [ ] ENV-001 documents all development tools
+- [ ] All tools have install commands
+- [ ] All packages are in package manifest
+- [ ] Configuration files are listed with purpose
+- [ ] Standard scripts defined (validate, fix, test)
+- [ ] Verification commands work
+- [ ] CLI preferred over MCP documented
+
+## Downstream Connections
+
+ENV- entries feed into:
+
+| Consumer | What It Uses | Example |
+|----------|--------------|---------|
+| **v0.7 Build Execution** | ENV-001 defines dev setup | Developer follows ENV-001 to set up |
+| **Onboarding** | ENV-001 as setup guide | New dev uses ENV-001 for first day |
+| **CI/CD** | ENV-002 defines pipeline | GitHub Actions mirrors ENV-002 |
+| **Deployment** | ENV-003 defines infrastructure | DEP- references ENV-003 |
+
+## Detailed References
+
+- **ENV- entry template**: See `assets/env.md`
+- **Environment examples**: See `references/examples.md`

--- a/.claude/skills/prd-v06-environment-setup/assets/env.md
+++ b/.claude/skills/prd-v06-environment-setup/assets/env.md
@@ -1,0 +1,227 @@
+# ENV- Entry Template
+
+Copy and customize this template for your project's environment specifications.
+
+---
+
+## ENV-001: Development Environment
+
+**ID**: ENV-001
+**Category**: Development Setup
+**Status**: Approved | Date: YYYY-MM-DD
+**Last Reviewed**: YYYY-MM-DD
+**Owner**: {Team/Person responsible}
+
+### Purpose
+
+Document the development environment requirements for this project. This enables:
+
+- Consistent setups across team members
+- Faster onboarding for new developers
+- AI agent environment understanding
+- Reproducible development builds
+
+### CLIs (Global System Tools)
+
+{List system-level tools installed via package manager}
+
+```bash
+# macOS (Homebrew)
+brew install {tool1} {tool2}
+
+# Linux (apt)
+apt install {tool1} {tool2}
+
+# Windows (winget/scoop)
+winget install {tool1} {tool2}
+```
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `{tool}` | `{version}` | {What it's used for} |
+
+### Language-Specific Packages (Per-Project)
+
+{List packages installed in project, not globally}
+
+```bash
+# Node.js/NPM
+npm install --save-dev {package1} {package2}
+
+# Python
+pip install --dev {package1} {package2}
+
+# Go
+go install {package1}@latest
+```
+
+| Package | Purpose |
+|---------|---------|
+| `{package}` | {What it's used for} |
+
+### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `{config-file}` | {What it configures} |
+
+### Scripts
+
+Add to your package manifest (package.json, pyproject.toml, etc.):
+
+```json
+{
+  "scripts": {
+    "validate": "{command to run all quality checks}",
+    "fix": "{command to auto-fix issues}",
+    "test": "{command to run tests}",
+    "build": "{command to build project}"
+  }
+}
+```
+
+### Environment Manager Tasks (Optional)
+
+If using mise, add to `.mise.toml`:
+
+```toml
+[tasks.validate]
+run = "{quality check command}"
+description = "Run all quality checks"
+
+[tasks.fix]
+run = "{auto-fix command}"
+description = "Auto-fix code issues"
+```
+
+### MCPs (Only if CLIs Insufficient)
+
+**Rule**: Prefer CLIs over MCPs when both are available.
+
+| Operation | CLI | MCP | Decision |
+|-----------|-----|-----|----------|
+| {operation} | {cli-name or "None"} | {mcp-name or "None"} | {Use CLI / Use MCP / N/A} |
+
+### Verification
+
+```bash
+# 1. Verify system tools installed
+{tool1} --version
+{tool2} --version
+
+# 2. Verify project packages installed
+npm list --dev  # or equivalent
+
+# 3. Verify quality checks work
+npm run validate  # or equivalent
+
+# 4. Verify tests pass
+npm test  # or equivalent
+
+# 5. Verify build works
+npm run build  # or equivalent
+```
+
+### Troubleshooting
+
+**Issue**: {Common problem}
+**Fix**: {Solution}
+
+**Issue**: {Another common problem}
+**Fix**: {Solution}
+
+### Related IDs
+
+- [TECH-XXX](../SoT.TECHNICAL_DECISIONS.md#tech-xxx) - {Technology this environment supports}
+- [ARC-XXX](../SoT.TECHNICAL_DECISIONS.md#arc-xxx) - {Architecture context}
+
+---
+
+## ENV-002: CI/CD Pipeline (Optional)
+
+**ID**: ENV-002
+**Category**: Automation
+**Status**: Approved | Date: YYYY-MM-DD
+**Owner**: {Team/Person responsible}
+
+### Purpose
+
+Document CI/CD pipeline configuration for automated testing and deployment.
+
+### Workflow Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/{name}.yml` | {What this workflow does} |
+
+### Required Secrets
+
+| Secret | Purpose | Where to Set |
+|--------|---------|--------------|
+| `{SECRET_NAME}` | {Purpose} | GitHub Settings → Secrets |
+
+### Pipeline Stages
+
+1. **Checkout**: Clone repository
+2. **Setup**: Install dependencies (mirrors ENV-001)
+3. **Validate**: Run quality checks
+4. **Test**: Run test suite
+5. **Build**: Create artifacts
+6. **Deploy**: Deploy to environment (if applicable)
+
+### Environment Matrix
+
+| Environment | Trigger | Target |
+|-------------|---------|--------|
+| `staging` | Push to `main` | {staging URL} |
+| `production` | Release tag | {production URL} |
+
+### Related IDs
+
+- [ENV-001](#env-001-development-environment) - Local environment this mirrors
+- [DEP-XXX](../SoT.DEPLOYMENT.md#dep-xxx) - Deployment procedures
+
+---
+
+## ENV-003: Production Infrastructure (Optional)
+
+**ID**: ENV-003
+**Category**: Infrastructure
+**Status**: Approved | Date: YYYY-MM-DD
+**Owner**: {Team/Person responsible}
+
+### Purpose
+
+Document production hosting and services configuration.
+
+### Hosting Platform
+
+**Provider**: {AWS / GCP / Vercel / etc.}
+**Region**: {Region}
+**Tier**: {Free / Paid tier}
+
+### Environment Variables
+
+| Variable | Purpose | Required | Default |
+|----------|---------|----------|---------|
+| `{VAR_NAME}` | {Purpose} | Yes/No | {default or "None"} |
+
+### Services
+
+| Service | Purpose | Connection Method |
+|---------|---------|-------------------|
+| Database | {e.g., PostgreSQL} | {Connection string env var} |
+| Cache | {e.g., Redis} | {Connection details} |
+| Storage | {e.g., S3} | {Bucket configuration} |
+
+### Scaling Configuration
+
+| Resource | Min | Max | Trigger |
+|----------|-----|-----|---------|
+| {e.g., Web instances} | 1 | 10 | CPU > 70% |
+
+### Related IDs
+
+- [DEP-XXX](../SoT.DEPLOYMENT.md#dep-xxx) - Deployment procedures
+- [MON-XXX](../SoT.DEPLOYMENT.md#mon-xxx) - Monitoring setup
+- [RUN-XXX](../SoT.DEPLOYMENT.md#run-xxx) - Operational runbooks

--- a/.claude/skills/prd-v06-environment-setup/references/examples.md
+++ b/.claude/skills/prd-v06-environment-setup/references/examples.md
@@ -1,0 +1,410 @@
+# Environment Setup Examples
+
+Real-world examples of ENV- specifications for different tech stacks.
+
+---
+
+## Example 1: Node.js/TypeScript Web Application
+
+### ENV-001: Development Environment
+
+**ID**: ENV-001
+**Category**: Development Setup
+**Status**: Approved | Date: 2026-01-15
+**Owner**: Engineering Team
+
+#### CLIs (Global)
+
+```bash
+# macOS
+brew install mise jq gh ripgrep httpie
+
+# Linux
+apt install jq gh ripgrep
+curl https://mise.run | sh
+```
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `mise` | latest | Version manager for Node.js |
+| `jq` | 1.7+ | JSON processing |
+| `gh` | 2.x | GitHub CLI for PR workflows |
+| `rg` | 14.x | Fast code search |
+
+#### Packages (Per-Project)
+
+```bash
+npm install --save-dev \
+  typescript \
+  eslint \
+  prettier \
+  @typescript-eslint/parser \
+  @typescript-eslint/eslint-plugin \
+  jest \
+  @types/jest
+```
+
+| Package | Purpose |
+|---------|---------|
+| `typescript` | Type checking |
+| `eslint` | Linting |
+| `prettier` | Code formatting |
+| `jest` | Testing framework |
+
+#### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `tsconfig.json` | TypeScript compiler options |
+| `.eslintrc.js` | ESLint rules |
+| `.prettierrc` | Prettier formatting |
+| `jest.config.js` | Test configuration |
+| `.mise.toml` | Tool versions |
+
+#### Scripts (package.json)
+
+```json
+{
+  "scripts": {
+    "validate": "npm run lint && npm run typecheck && npm run test",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "fix": "npm run lint:fix && npm run format",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "build": "tsc"
+  }
+}
+```
+
+#### Environment Manager (.mise.toml)
+
+```toml
+[tools]
+node = "20"
+
+[tasks.validate]
+run = "npm run validate"
+description = "Run all quality checks"
+
+[tasks.fix]
+run = "npm run fix"
+description = "Auto-fix code issues"
+```
+
+#### Verification
+
+```bash
+# 1. Verify mise and Node
+mise --version
+node --version  # Should show v20.x
+
+# 2. Verify project setup
+npm install
+npm list --dev | head -20
+
+# 3. Verify quality checks
+npm run validate
+
+# 4. Verify build
+npm run build
+```
+
+#### Related IDs
+
+- TECH-001: Next.js framework selection
+- TECH-002: TypeScript strict mode decision
+- ARC-001: Monolith structure
+
+---
+
+## Example 2: Python Data Science Project
+
+### ENV-001: Development Environment
+
+**ID**: ENV-001
+**Category**: Development Setup
+**Status**: Approved | Date: 2026-01-15
+**Owner**: Data Team
+
+#### CLIs (Global)
+
+```bash
+# macOS
+brew install mise jq httpie
+
+# Linux
+curl https://mise.run | sh
+apt install jq
+```
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `mise` | latest | Manages Python + tools |
+| `jq` | 1.7+ | JSON processing |
+
+#### Packages (Per-Project)
+
+```bash
+# Create virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dev dependencies
+pip install -e ".[dev]"
+```
+
+**pyproject.toml:**
+```toml
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "mypy",
+    "pytest",
+    "pytest-cov",
+    "ipykernel",
+]
+```
+
+| Package | Purpose |
+|---------|---------|
+| `ruff` | Fast linting + formatting |
+| `mypy` | Type checking |
+| `pytest` | Testing framework |
+| `pytest-cov` | Coverage reporting |
+
+#### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `pyproject.toml` | Project config, dependencies |
+| `ruff.toml` | Linting rules |
+| `.python-version` | Python version (mise) |
+
+#### Scripts (Makefile)
+
+```makefile
+.PHONY: validate lint format typecheck test fix
+
+validate: lint typecheck test
+
+lint:
+	ruff check .
+
+format:
+	ruff format .
+
+typecheck:
+	mypy src/
+
+test:
+	pytest --cov=src
+
+fix:
+	ruff check . --fix
+	ruff format .
+```
+
+#### Environment Manager (.mise.toml)
+
+```toml
+[tools]
+python = "3.12"
+
+[tasks.validate]
+run = "make validate"
+description = "Run all quality checks"
+
+[tasks.fix]
+run = "make fix"
+description = "Auto-fix code issues"
+```
+
+#### Verification
+
+```bash
+# 1. Verify Python version
+python --version  # Should show 3.12.x
+
+# 2. Verify venv and packages
+source .venv/bin/activate
+pip list | grep -E "ruff|mypy|pytest"
+
+# 3. Verify quality checks
+make validate
+```
+
+---
+
+## Example 3: Go Microservice
+
+### ENV-001: Development Environment
+
+**ID**: ENV-001
+**Category**: Development Setup
+**Status**: Approved | Date: 2026-01-15
+**Owner**: Platform Team
+
+#### CLIs (Global)
+
+```bash
+# macOS
+brew install mise jq gh golangci-lint
+
+# Linux
+curl https://mise.run | sh
+apt install jq
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+```
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `mise` | latest | Go version manager |
+| `golangci-lint` | 1.55+ | Meta-linter for Go |
+| `jq` | 1.7+ | JSON processing |
+
+#### Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `go.mod` | Module dependencies |
+| `.golangci.yml` | Linter configuration |
+| `Makefile` | Build/test commands |
+
+#### Scripts (Makefile)
+
+```makefile
+.PHONY: validate lint test build fix
+
+validate: lint test
+
+lint:
+	golangci-lint run
+
+test:
+	go test -v -race -coverprofile=coverage.out ./...
+
+build:
+	go build -o bin/app ./cmd/app
+
+fix:
+	golangci-lint run --fix
+	go fmt ./...
+```
+
+#### Verification
+
+```bash
+# 1. Verify Go version
+go version  # Should show 1.22.x
+
+# 2. Verify dependencies
+go mod download
+go mod verify
+
+# 3. Verify quality checks
+make validate
+
+# 4. Verify build
+make build
+```
+
+---
+
+## CLI vs MCP Decision Examples
+
+### Example: GitHub Operations
+
+| Operation | CLI | MCP | Decision |
+|-----------|-----|-----|----------|
+| Create PR | `gh pr create` | GitHub MCP | **CLI** - works in CI |
+| List issues | `gh issue list` | GitHub MCP | **CLI** - scriptable |
+| View PR diff | `gh pr diff` | GitHub MCP | **CLI** - standard output |
+
+### Example: Database Operations
+
+| Operation | CLI | MCP | Decision |
+|-----------|-----|-----|----------|
+| Run migrations | `prisma migrate` | None | **CLI** - only option |
+| Query data | `psql` / db CLI | DB MCP | **CLI** - works everywhere |
+| Generate types | `prisma generate` | None | **CLI** - build step |
+
+### Example: When MCP is Appropriate
+
+| Operation | CLI | MCP | Decision |
+|-----------|-----|-----|----------|
+| Jira ticket creation | None native | Jira MCP | **MCP** - no CLI available |
+| Confluence updates | None native | Confluence MCP | **MCP** - no CLI available |
+| Figma design access | None | Figma MCP | **MCP** - visual context needed |
+
+---
+
+## Common Verification Patterns
+
+### Node.js Project
+
+```bash
+#!/bin/bash
+set -e
+
+echo "=== Verifying Node.js Environment ==="
+
+# 1. Check Node version
+echo "Node: $(node --version)"
+[[ $(node --version) == v20* ]] || echo "Warning: Expected Node 20.x"
+
+# 2. Check npm packages
+npm install
+npm list --depth=0
+
+# 3. Run validation
+npm run validate
+
+echo "=== Environment verified ==="
+```
+
+### Python Project
+
+```bash
+#!/bin/bash
+set -e
+
+echo "=== Verifying Python Environment ==="
+
+# 1. Check Python version
+echo "Python: $(python --version)"
+
+# 2. Check venv
+[[ -d .venv ]] || python -m venv .venv
+source .venv/bin/activate
+
+# 3. Install and verify
+pip install -e ".[dev]"
+make validate
+
+echo "=== Environment verified ==="
+```
+
+### Go Project
+
+```bash
+#!/bin/bash
+set -e
+
+echo "=== Verifying Go Environment ==="
+
+# 1. Check Go version
+echo "Go: $(go version)"
+
+# 2. Verify modules
+go mod download
+go mod verify
+
+# 3. Run validation
+make validate
+
+echo "=== Environment verified ==="
+```

--- a/.claude/skills/skills-inventory.md
+++ b/.claude/skills/skills-inventory.md
@@ -23,6 +23,7 @@
 | **v0.5 Red Team Review** | [Technical Stack Selection](#skill-technical-stack-selection) | ✅ Ready | [`prd-v05-technical-stack-selection/`](prd-v05-technical-stack-selection/) |
 | **v0.6 Architecture** | [Architecture Design](#skill-architecture-design) | ✅ Ready | [`prd-v06-architecture-design/`](prd-v06-architecture-design/) |
 | **v0.6 Architecture** | [Technical Specification](#skill-technical-specification) | ✅ Ready | [`prd-v06-technical-specification/`](prd-v06-technical-specification/) |
+| **v0.6 Architecture** | [Environment Setup](#skill-environment-setup) | ✅ Ready | [`prd-v06-environment-setup/`](prd-v06-environment-setup/) |
 | **v0.7 Build Execution** | [Epic Scoping](#skill-epic-scoping) | ✅ Ready | [`prd-v07-epic-scoping/`](prd-v07-epic-scoping/) |
 | **v0.7 Build Execution** | [Test Planning](#skill-test-planning) | ✅ Ready | [`prd-v07-test-planning/`](prd-v07-test-planning/) |
 | **v0.7 Build Execution** | [Implementation Loop](#skill-implementation-loop) | ✅ Ready | [`prd-v07-implementation-loop/`](prd-v07-implementation-loop/) |
@@ -95,13 +96,14 @@
 
 ### v0.6 Architecture — Technical Blueprint
 
-**Purpose:** Define system architecture and implementation contracts based on stack selections.
-**Gate:** Architecture decisions documented, API contracts defined, data models specified, integration patterns established.
+**Purpose:** Define system architecture, implementation contracts, and environment specifications based on stack selections.
+**Gate:** Architecture decisions documented, API contracts defined, data models specified, environment setup documented.
 
 | Skill | Input | Output | IDs Created |
 |-------|-------|--------|-------------|
 | Architecture Design | TECH- (stack), RISK- (constraints), FEA- (features) | System architecture with component relationships | ARC- |
 | Technical Specification | ARC- (architecture), TECH- (Build items), UJ- (flows), SCR- (screens) | API contracts and data models | API-, DBT- |
+| Environment Setup | TECH- (stack), ARC- (architecture) | Development environment, CI/CD, infrastructure specs | ENV- |
 
 ### v0.7 Build Execution — Implementation
 
@@ -1264,6 +1266,86 @@ Business Rules: [BR-XXX that affect this entity]
 | **v0.7 Build Execution** | API- and DBT- are implementation tasks | EPIC-01 implements API-001–005 |
 | **Testing** | API- defines test contracts | TEST-001 validates API-001 |
 | **Documentation** | API- becomes API docs | OpenAPI spec from API- entries |
+
+---
+
+### SKILL: Environment Setup
+
+```yaml
+name: prd-v06-environment-setup
+stage: v0.6
+status: ready
+folder: prd-v06-environment-setup/
+triggers: "what tools do I need", "environment setup", "dev environment", "CLI requirements", "project setup", "onboarding setup"
+id_outputs: [ENV-]
+```
+
+**Purpose:** Document development environment requirements for team consistency and AI agent understanding.
+
+**Position in workflow:** v0.6 Architecture / Technical Spec → **v0.6 Environment Setup** → v0.7 Build Execution
+
+**Mode:** Documentation — AI helps structure requirements, developer provides tool choices.
+
+**Execution:**
+1. Pull TECH- decisions (what technologies are we using?)
+2. Pull ARC- decisions (what architecture patterns apply?)
+3. Inventory tooling needs (CLIs, packages, configs)
+4. Categorize by scope (global vs per-project)
+5. Define configuration files with purpose
+6. Create verification commands
+7. Document in ENV- entries
+
+**Design Principles:**
+- **Prefer CLIs over MCPs** — CLIs work in all environments (local, CI/CD, cloud)
+- **Per-project over global** — Language packages in project, not global installs
+- **Structured over prose** — Tables and code blocks, not narrative paragraphs
+- **Verification required** — Every ENV- includes commands to confirm setup
+
+**ENV-001 Output Template:**
+```
+ENV-001: Development Environment
+Category: Development Setup
+Status: Approved | Date: YYYY-MM-DD
+Owner: {Team/Person}
+
+CLIs (Global):
+- {tool}: {purpose} — {install command}
+
+Packages (Per-Project):
+- {package}: {purpose}
+
+Configuration Files:
+| File | Purpose |
+|------|---------|
+| {file} | {purpose} |
+
+Scripts:
+{
+  "validate": "{quality check command}",
+  "fix": "{auto-fix command}",
+  "test": "{test command}"
+}
+
+Verification:
+# Commands to confirm environment is ready
+{verification commands}
+
+Related IDs: TECH-XXX, ARC-XXX
+```
+
+**Anti-Patterns:**
+| Pattern | Signal | Fix |
+|---------|--------|-----|
+| Global package pollution | `npm install -g` for project packages | Use devDependencies |
+| Missing verification | No way to confirm setup | Add verification commands |
+| MCP over CLI | Using MCP when CLI exists | Prefer CLI for portability |
+
+**Downstream Connections:**
+| Consumer | What It Uses | Example |
+|----------|--------------|---------|
+| **v0.7 Build Execution** | ENV-001 defines dev setup | Developer follows ENV-001 |
+| **Onboarding** | ENV-001 as setup guide | New dev uses ENV-001 |
+| **CI/CD** | ENV-002 defines pipeline | GitHub Actions mirrors ENV-002 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ We organize the repository to reflect how intelligence functions. This hierarchy
 | File | Purpose |
 |:-----|:--------|
 | [`README.md`](README.md) | **The Dashboard.** Current status, priorities, and project instincts. |
-| [`PRD.md`](PRD.md) | **The Progressive Strategy.** A gated document that defines the "Why" and "What." It evolves in place from v0.1 (Spark) to v1.0 (Growth). For this lifecycle I've built my 20 years as a product manager into [24 skills](.claude/skills/skills-inventory.md) that guide the PRD progress into building market-ready products. |
+| [`PRD.md`](PRD.md) | **The Progressive Strategy.** A gated document that defines the "Why" and "What." It evolves in place from v0.1 (Spark) to v1.0 (Growth). For this lifecycle I've built my 20 years as a product manager into [25 skills](.claude/skills/skills-inventory.md) that guide the PRD progress into building market-ready products. |
 | [`CLAUDE.md`](CLAUDE.md) | **The Physics.** The non-negotiable rules of behavior and technical standards. |
 
 ### Long-Term Memory (The Anchors)
 
 | Directory | Purpose |
 |:----------|:--------|
-| [`SoT/`](SoT/) | **The Source of Truth.** This holds immutable facts: [Business Rules (`BR-`)](SoT/SoT.BUSINESS_RULES.md), [User Journeys (`UJ-`)](SoT/SoT.USER_JOURNEYS.md), [Data Contracts (`API-`)](SoT/SoT.API_CONTRACTS.md), and other key decisions as easy-to-reference anchors that prevent model drift. |
+| [`SoT/`](SoT/) | **The Source of Truth.** This holds immutable facts: [Business Rules (`BR-`)](SoT/SoT.BUSINESS_RULES.md), [User Journeys (`UJ-`)](SoT/SoT.USER_JOURNEYS.md), [Data Contracts (`API-`)](SoT/SoT.API_CONTRACTS.md), [Technical Decisions (`TECH-`, `ARC-`, `ENV-`)](SoT/SoT.TECHNICAL_DECISIONS.md), and other key decisions as easy-to-reference anchors that prevent model drift. |
 
 See the complete [SoT Index](SoT/SoT.README.md) and [Unique ID System](SoT/SoT.UNIQUE_ID_SYSTEM.md) for details.
 

--- a/SoT/SoT.README.md
+++ b/SoT/SoT.README.md
@@ -1,7 +1,7 @@
 ---
 title: "Source-of-Truth Library Guide"
 scope: "SoT/"
-updated: "2026-01-12"
+updated: "2026-01-18"
 ---
 
 # Source-of-Truth (SoT) Library
@@ -23,7 +23,7 @@ Each file focuses on one artifact type with a consistent ID prefix (~100-150 lin
 | `SoT.DEPLOYMENT.md` | DEP, RUN, MON | Deployment, runbooks, monitoring |
 | `SoT.customer_feedback.md` | CFD-XXX | Customer feedback and insights |
 | `SoT.DESIGN_COMPONENTS.md` | DES-XXX | UI components and design tokens |
-| `SoT.TECHNICAL_DECISIONS.md` | TECH, ARC | Tech stack and architecture |
+| `SoT.TECHNICAL_DECISIONS.md` | TECH, ARC, ENV | Tech stack, architecture & environment |
 | `SoT.INTEGRATIONS.md` | INT-XXX | Third-party service integrations |
 
 **IDs in PRD/README** (not SoT files): FEA-XXX, RISK-XXX, GTM-XXX, KPI-XXX

--- a/SoT/SoT.TECHNICAL_DECISIONS.md
+++ b/SoT/SoT.TECHNICAL_DECISIONS.md
@@ -1,15 +1,15 @@
 ---
-version: 1.0
-purpose: Source of Truth for technology choices and architecture decisions (ADR-style).
-id_prefix: TECH-XXX, ARC-XXX
-last_updated: YYYY-MM-DD
+version: 1.1
+purpose: Source of Truth for technology choices, architecture decisions, and environment specifications.
+id_prefix: TECH-XXX, ARC-XXX, ENV-XXX
+last_updated: 2026-01-18
 authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and code
 ---
 
 # Technical Decisions (SoT File)
 
-> **Purpose**: Record technology selections and architecture decisions with rationale.
-> **ID Prefixes**: TECH-XXX (stack decisions), ARC-XXX (architecture decisions)
+> **Purpose**: Record technology selections, architecture decisions, and environment specifications.
+> **ID Prefixes**: TECH-XXX (stack decisions), ARC-XXX (architecture decisions), ENV-XXX (environment setup)
 > **Status**: Active SoT file
 > **Cross-References**: Referenced by PRD.md v0.5-v0.6, SoT.API_CONTRACTS.md, EPICs
 
@@ -22,6 +22,10 @@ authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and co
 **Architecture Decisions** (ARC-001 to ARC-099):
 
 - [ARC-001](#arc-001-decision-name) - {Architecture decision}
+
+**Environment Specifications** (ENV-001 to ENV-099):
+
+- [ENV-001](#env-001-development-environment) - Development environment setup
 
 ---
 
@@ -85,6 +89,199 @@ authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and co
 
 ---
 
+## ENV-001: Development Environment
+
+**ID**: ENV-001
+**Category**: Development Setup
+**Status**: Template | Date: YYYY-MM-DD
+**Last Reviewed**: YYYY-MM-DD
+**Owner**: {Team/Person responsible}
+
+### Purpose
+
+Document the development environment requirements for this project. This enables:
+
+- Consistent setups across team members
+- Faster onboarding for new developers
+- AI agent environment understanding
+- Reproducible development builds
+
+### CLIs (Global System Tools)
+
+{List system-level tools installed via package manager}
+
+```bash
+# Example installation commands (customize for your project)
+# brew install [tool1] [tool2]  # macOS
+# apt install [tool1] [tool2]   # Linux
+```
+
+**Common categories:**
+
+- Version managers (mise, asdf, nvm, pyenv)
+- Data processing (jq, yq)
+- API testing (httpie, curl)
+- Search tools (ripgrep)
+- Git workflows (gh CLI)
+
+### Language-Specific Packages (Per-Project)
+
+{List packages installed in project, not globally}
+
+```bash
+# Example for Node/NPM projects
+# npm install --save-dev [package1] [package2]
+
+# Example for Python projects
+# pip install --dev [package1] [package2]
+```
+
+**Common categories:**
+
+- Linting (eslint, ruff, golangci-lint)
+- Formatting (prettier, black)
+- Type checking (typescript, mypy)
+- Testing (jest, pytest)
+
+### Configuration Files
+
+{List configuration files with brief purpose}
+
+| File | Purpose |
+|------|---------|
+| `{config-file}` | {What it configures} |
+
+### Scripts
+
+{Define standard scripts in package manifest}
+
+```json
+{
+  "scripts": {
+    "validate": "{command to run all quality checks}",
+    "fix": "{command to auto-fix issues}",
+    "test": "{command to run tests}"
+  }
+}
+```
+
+### Environment Manager Tasks (Optional)
+
+{If using mise, asdf, direnv, etc.}
+
+```toml
+# Example for mise (.mise.toml)
+# [tasks.validate]
+# run = "{quality check command}"
+# description = "{what this validates}"
+```
+
+### MCPs (Only if CLIs Insufficient)
+
+**Rule**: Prefer CLIs over MCPs when both are available.
+
+| Operation | CLI Available | MCP Available | Use |
+|-----------|---------------|---------------|-----|
+| {operation} | {yes/no + name} | {yes/no + name} | {CLI/MCP} |
+
+**Rationale**: CLIs work in all environments (local, CI/CD, cloud). MCPs only work in specific contexts.
+
+### Verification
+
+```bash
+# Commands to verify environment is set up correctly
+
+# 1. Verify system tools
+# [tool1] --version
+# [tool2] --version
+
+# 2. Verify project packages
+# {package manager ls command}
+
+# 3. Verify quality checks work
+# npm run validate  # or equivalent
+
+# 4. Verify tests pass
+# npm test  # or equivalent
+```
+
+### Troubleshooting
+
+**Issue**: {Common problem}
+**Fix**: {Solution}
+
+### Related IDs
+
+- [TECH-XXX](#tech-xxx-decision-name) - {Technology this environment supports}
+- [ARC-XXX](#arc-xxx-decision-name) - {Architecture context}
+
+---
+
+## ENV-002: CI/CD Pipeline (Optional)
+
+**ID**: ENV-002
+**Category**: Automation
+**Status**: Template | Date: YYYY-MM-DD
+
+### Purpose
+
+Document CI/CD pipeline configuration for automated testing and deployment.
+
+### Workflow Files
+
+{Reference workflow configuration files}
+
+### Required Secrets
+
+| Secret | Purpose | Where to Set |
+|--------|---------|--------------|
+| `{SECRET_NAME}` | {Purpose} | {GitHub/GitLab settings} |
+
+### Pipeline Stages
+
+1. **{Stage Name}**: {What happens}
+2. **{Stage Name}**: {What happens}
+
+### Related IDs
+
+- [ENV-001](#env-001-development-environment) - Local environment this mirrors
+- [DEP-XXX](SoT.DEPLOYMENT.md#dep-xxx) - Deployment steps
+
+---
+
+## ENV-003: Production Infrastructure (Optional)
+
+**ID**: ENV-003
+**Category**: Infrastructure
+**Status**: Template | Date: YYYY-MM-DD
+
+### Purpose
+
+Document production hosting and services configuration.
+
+### Hosting Platform
+
+{Platform name and configuration}
+
+### Environment Variables
+
+| Variable | Purpose | Required |
+|----------|---------|----------|
+| `{VAR_NAME}` | {Purpose} | {Yes/No} |
+
+### Services
+
+| Service | Purpose | Connection |
+|---------|---------|------------|
+| {Service} | {Purpose} | {How connected} |
+
+### Related IDs
+
+- [DEP-XXX](SoT.DEPLOYMENT.md#dep-xxx) - Deployment procedures
+- [MON-XXX](SoT.DEPLOYMENT.md#mon-xxx) - Monitoring setup
+
+---
+
 ## Deprecated Decisions
 
 ### TECH-XXX: {Decision Name} [SUPERSEDED]
@@ -102,10 +299,11 @@ authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and co
 
 - Frontend: TECH-001, ARC-001
 - Backend: TECH-002, ARC-002
+- Environment: ENV-001, ENV-002, ENV-003
 
 **Decisions by EPIC**:
 
-- EPIC-01 implemented: TECH-001, ARC-001
+- EPIC-01 implemented: TECH-001, ARC-001, ENV-001
 
 ---
 
@@ -115,10 +313,11 @@ authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and co
 
 1. **TECH-XXX**: Selecting a new technology, framework, or tool
 2. **ARC-XXX**: Making a structural decision about system design
+3. **ENV-XXX**: Documenting environment requirements (dev setup, CI/CD, infrastructure)
 
 ### Bidirectional Reference Checklist
 
-When adding a new TECH/ARC-XXX:
+When adding a new TECH/ARC/ENV-XXX:
 
 - [ ] Update PRD.md v0.5/v0.6 section if applicable
 - [ ] Update related API contracts if affected
@@ -127,4 +326,4 @@ When adding a new TECH/ARC-XXX:
 
 ---
 
-*End of SoT.TECHNICAL_DECISIONS.md - Authoritative source for TECH-XXX and ARC-XXX IDs*
+*End of SoT.TECHNICAL_DECISIONS.md - Authoritative source for TECH-XXX, ARC-XXX, and ENV-XXX IDs*

--- a/SoT/SoT.UNIQUE_ID_SYSTEM.md
+++ b/SoT/SoT.UNIQUE_ID_SYSTEM.md
@@ -37,6 +37,7 @@ This file serves as the **governance guide** for the ID system and the **central
 | **DES** | Design Component | `SoT.DESIGN_COMPONENTS.md` | v0.4 User Journeys |
 | **TECH** | Tech Stack | `SoT.TECHNICAL_DECISIONS.md` | v0.5 Red Team |
 | **ARC** | Architecture | `SoT.TECHNICAL_DECISIONS.md` | v0.6 Architecture |
+| **ENV** | Environment Setup | `SoT.TECHNICAL_DECISIONS.md` | v0.6 Architecture |
 | **INT** | Integration | `SoT.INTEGRATIONS.md` | v0.6 Architecture |
 | **API** | API Contract | `SoT.API_CONTRACTS.md` | v0.6 Architecture |
 | **DBT** | Data Schema | `SoT.DATA_MODEL.md` | v0.6 Architecture |
@@ -113,7 +114,7 @@ CFD-089 (Request: Dark Mode)
 | `SoT.DEPLOYMENT.md` | DEP, RUN, MON | ~130 | Operations & deployment |
 | `SoT.customer_feedback.md` | CFD-XXX | ~120 | Customer insights |
 | `SoT.DESIGN_COMPONENTS.md` | DES-XXX | ~100 | UI components |
-| `SoT.TECHNICAL_DECISIONS.md` | TECH, ARC | ~115 | Tech & architecture |
+| `SoT.TECHNICAL_DECISIONS.md` | TECH, ARC, ENV | ~130 | Tech, architecture & environment |
 | `SoT.INTEGRATIONS.md` | INT-XXX | ~105 | Third-party services |
 
 ---
@@ -132,6 +133,7 @@ When forking, validate:
 
 | Date | Change |
 |------|--------|
+| 2026-01-18 | Added ENV-XXX prefix for development environment specifications |
 | 2026-01-12 | Standardized: Updated file references, added INT-XXX, clarified PRD vs SoT homes |
 | 2026-01-12 | Added 8 missing ID prefixes. Organized by PRD stage |
 | 2025-12-22 | Combined UNIQUE_ID_SYSTEM and ID_REGISTRY into one |


### PR DESCRIPTION
Add ENV-XXX prefix to document development environment requirements, CI/CD pipelines, and production infrastructure configurations.

Changes:
- Add ENV- prefix to SoT.UNIQUE_ID_SYSTEM.md registry
- Add ENV-001/002/003 templates to SoT.TECHNICAL_DECISIONS.md
- Create prd-v06-environment-setup skill with templates and examples
- Update skills-inventory.md with new v0.6 skill (now 25 skills)
- Update README.md to reference ENV- in SoT description

Design principles:
- Prefer CLIs over MCPs for portability
- Per-project packages over global installs
- Structured data (tables, code blocks) over prose
- Verification commands required for every ENV- spec

This enables teams to document their tooling choices in a structured way that both humans and AI agents can parse and execute.