### PR TITLE
Document Just-In-Time Context (JIT-C) compliance across all agents

### DIFF
--- a/.claude/agents/devlab/AGENT.md
+++ b/.claude/agents/devlab/AGENT.md
@@ -74,6 +74,36 @@ Before working, ensure you have loaded:
 | v0.7 | Complete API-/DBT-/ARC-, current EPIC, TEST- for scope |
 | v0.8 | All EPICs complete, DEP- drafts, RUN- drafts, MON- requirements |
 
+## Context Handling (JIT-C Compliance)
+
+### What This Agent Receives
+- Handoff contract from STUDIO (DES- summaries + implementation refs)
+- Handoff contract from HORIZON (BR-/UJ- summaries + constraint refs)
+- Active EPIC with pre-load manifest
+- Task ledger with technical questions
+
+### What This Agent Loads On-Demand
+- `SoT/SoT.BUSINESS_RULES.md` — when validating implementation against BR-
+- `SoT/SoT.USER_JOURNEYS.md` — when implementing specific UJ- flows
+- `SoT/SoT.DESIGN_COMPONENTS.md` — when building DES- components
+- `SoT/SoT.API_CONTRACTS.md` — when referencing existing API- patterns
+- `SoT/SoT.TECHNICAL_DECISIONS.md` — when checking ARC-/TECH- precedents
+
+### What This Agent Produces
+- Architecture decisions → `ARC-xxx` entries in `SoT/SoT.TECHNICAL_DECISIONS.md`
+- API contracts → `API-xxx` entries in `SoT/SoT.API_CONTRACTS.md`
+- Database models → `DBT-xxx` entries in `SoT/SoT.DATA_MODEL.md`
+- Test specs → `TEST-xxx` entries in `SoT/SoT.TESTING.md`
+- Deployment config → `DEP-xxx` entries in `SoT/SoT.DEPLOYMENT.md`
+- Handoff contract for METRO (release notes + deployment refs)
+
+### What This Agent Does NOT Pass Forward
+- Full conversation history from implementation sessions
+- Build logs or debug session notes
+- Dependency upgrade experiment branches
+- Performance profiling raw data
+- Tool call logs from coding sessions
+
 ## Primary Responsibilities
 
 - Define system architecture with API contracts (v0.6)

--- a/.claude/agents/horizon/AGENT.md
+++ b/.claude/agents/horizon/AGENT.md
@@ -74,6 +74,30 @@ Before working, ensure you have loaded:
 | v0.4 | v0.3 complete, user research artifacts, STUDIO collaboration |
 | v0.5 | v0.4 complete, DEVLAB technical input, all BR-/UJ-/PER- |
 
+## Context Handling (JIT-C Compliance)
+
+### What This Agent Receives
+- Handoff contract from METRO (summaries + handles only for iteration cycles)
+- Active SoT references relevant to current PRD stage
+- Task ledger with open questions assigned to HORIZON
+
+### What This Agent Loads On-Demand
+- `SoT/SoT.BUSINESS_RULES.md` — when validating market constraints
+- `SoT/SoT.customer_feedback.md` — when positioning requires competitor context
+- Previous product feedback (CFD-) from METRO if v1.1+ iteration cycle
+
+### What This Agent Produces
+- Market analysis artifacts → PRD.md sections (v0.1–v0.5)
+- Business rules → `BR-xxx` entries in `SoT/SoT.BUSINESS_RULES.md`
+- User journeys → `UJ-xxx` entries in `SoT/SoT.USER_JOURNEYS.md`
+- Handoff contract for STUDIO/DEVLAB (summaries of findings + refs)
+
+### What This Agent Does NOT Pass Forward
+- Full conversation history from research sessions
+- Raw interview transcripts or research URLs
+- Intermediate reasoning chains from ICP analysis
+- Tool call logs from competitive research
+
 ## Primary Responsibilities
 
 - Frame problems with measurable outcomes (v0.1 Spark)

--- a/.claude/agents/metro/AGENT.md
+++ b/.claude/agents/metro/AGENT.md
@@ -69,6 +69,33 @@ Before working, ensure you have loaded:
 | v0.9 | PRD v0.8+, DEP- documentation, feature list from DEVLAB, KPI- targets |
 | v1.0 | Complete GTM-, CFD- post-launch, adoption metrics, channel data |
 
+## Context Handling (JIT-C Compliance)
+
+### What This Agent Receives
+- Handoff contract from DEVLAB (release notes + deployment refs)
+- Feature documentation summaries for marketing
+- Known limitations list with handles to technical details
+- Task ledger with GTM questions
+
+### What This Agent Loads On-Demand
+- `SoT/SoT.DEPLOYMENT.md` — when configuring launch operations
+- `SoT/SoT.customer_feedback.md` — when categorizing new feedback against existing CFD-
+- PRD.md persona section — when targeting messaging to specific PER-
+- Previous GTM- entries — when referencing channel/messaging precedents
+
+### What This Agent Produces
+- Launch plan → `GTM-xxx` entries in PRD.md v0.9 section
+- Monitoring config → `MON-xxx` entries in `SoT/SoT.DEPLOYMENT.md`
+- Customer feedback → `CFD-xxx` entries in `SoT/SoT.customer_feedback.md`
+- Handoff contract for HORIZON (iteration insights + feedback refs)
+
+### What This Agent Does NOT Pass Forward
+- Full conversation history from launch sessions
+- Campaign draft iterations
+- Social post variations or A/B test versions
+- Raw analytics exports
+- Tool call logs from metric analysis
+
 ## Primary Responsibilities
 
 - Define launch plan with channel strategy (v0.9)

--- a/.claude/agents/studio/AGENT.md
+++ b/.claude/agents/studio/AGENT.md
@@ -66,6 +66,31 @@ Before working, ensure you have loaded:
 | v0.4 | Complete UJ-, PER- personas, user research in temp/ |
 | v0.6 | All SCR-/DES-, DEVLAB technical constraints, component library caps |
 
+## Context Handling (JIT-C Compliance)
+
+### What This Agent Receives
+- Handoff contract from HORIZON (summaries of UJ-/BR- + handles only)
+- Active SoT references relevant to design phase
+- Task ledger with open questions assigned to STUDIO
+
+### What This Agent Loads On-Demand
+- `SoT/SoT.USER_JOURNEYS.md` — when designing screens for specific journeys
+- `SoT/SoT.BUSINESS_RULES.md` — when constraints affect UX decisions
+- `SoT/SoT.DESIGN_COMPONENTS.md` — when referencing existing patterns
+- User research artifacts in `temp/` — only when validating specific designs
+
+### What This Agent Produces
+- Screen definitions → `SCR-xxx` entries in `SoT/SoT.USER_JOURNEYS.md`
+- Design components → `DES-xxx` entries in `SoT/SoT.DESIGN_COMPONENTS.md`
+- Design system tokens → specifications in `SoT/SoT.DESIGN_COMPONENTS.md`
+- Handoff contract for DEVLAB (component specs + implementation refs)
+
+### What This Agent Does NOT Pass Forward
+- Full conversation history from design sessions
+- Figma iteration history or rejected mockups
+- User test session recordings
+- Intermediate design explorations
+
 ## Primary Responsibilities
 
 - Synthesize user research into design requirements (v0.3–v0.4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,30 @@ The methodology uses a layered document structure:
 - **Consolidation**: Validation and Verification steps should happen in bulk to save tokens.
 - **Pruning**: if context is full, suggest a `session_handoff` where you summarize state and clear history.
 
+### Just-In-Time Context (JIT-C)
+
+Agents hold handles to artifacts, not content. This is a structural discipline, not a suggestion.
+
+**Rules**:
+1. **Never context dump**: Do not place full SoT documents in handoffs or prompts
+2. **Reference by ID**: Use Unique IDs (`BR-001`, `UJ-101`) as retrieval handles
+3. **Load on demand**: Retrieve specific content only when reasoning requires it
+4. **Offload after use**: Artifacts exit working context after task completion
+5. **Summarize at boundaries**: Phase handoffs include 75-word summaries, not full content
+
+**Handoff format**:
+```
+Artifact: {ID}
+Summary: {75-word max}
+Path: {SoT/file.md}
+Status: {reference-only | loaded | offloaded}
+```
+
+**Violation indicators**:
+- Handoff contracts exceeding 2K tokens of artifact content
+- Agents receiving full conversation history from previous phases
+- Context window >50% filled before agent begins work
+
 ### Coding Standards
 
 #### Traceability Protocol (MANDATORY)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ We often mistake an agent's "role" for its "instructions." In this system, **Ide
 | Principle | Description |
 |:----------|:------------|
 | **Unique IDs as Nodes** | Using `BR-101` or `UJ-202` turns flat files into a queryable **Knowledge Graph**. It allows for deterministic retrieval instead of probabilistic guessing. |
-| **Just-in-Time Context** | We use those IDs to pull only the specific nodes of memory required for a task, maintaining optimal **Context Density**. |
+| **Just-in-Time Context (JIT-C)** | Agents hold handles to knowledge, not knowledge itself. IDs (`BR-xxx`, `UJ-xxx`) enable on-demand loading without context pollution. The discipline: pass references + summaries (not full content), retrieve when reasoning requires it, cap retrieval at ~2K tokens, offload after task completion. Multi-agent handoffs pass handles, not content—preventing context rot by phase 3. |
 | **Progressive Documentation** | We update in place. As the product matures, the documentation matures with it, ensuring there is only ever one version of the truth. |
 | **Gated Workflows** | We verify that the memory (the PRD and SoT) is valid before we allow the system to move from strategy to implementation. |
 


### PR DESCRIPTION
## Summary
This PR formalizes the Just-In-Time Context (JIT-C) discipline across the multi-agent system by documenting context handling patterns for each agent (DEVLAB, HORIZON, METRO, STUDIO) and establishing JIT-C as a structural requirement in the methodology.

## Changes

### Agent Documentation Updates
- **DEVLAB** (`agents/devlab/AGENT.md`): Added "Context Handling (JIT-C Compliance)" section documenting what the agent receives, loads on-demand, produces, and explicitly does NOT pass forward (conversation history, build logs, debug notes, profiling data, tool call logs)
- **HORIZON** (`agents/horizon/AGENT.md`): Added context handling section specifying handoff contracts from METRO, on-demand loading of business rules and customer feedback, and exclusion of raw research artifacts and interview transcripts
- **METRO** (`agents/metro/AGENT.md`): Added context handling section for launch operations, specifying on-demand loading of deployment docs and customer feedback, with explicit exclusion of campaign drafts and analytics exports
- **STUDIO** (`agents/studio/AGENT.md`): Added context handling section for design phase, documenting on-demand loading of user journeys and design components, excluding Figma history and design explorations

### Methodology Documentation
- **CLAUDE.md**: Added "Just-In-Time Context (JIT-C)" subsection under methodology that establishes:
  - 5 core rules (no context dumps, reference by ID, load on-demand, offload after use, summarize at boundaries)
  - Standardized handoff format with artifact ID, summary, path, and status
  - Violation indicators (handoff contracts >2K tokens, full conversation history, context >50% before work begins)

- **README.md**: Expanded "Just-In-Time Context" principle description to clarify that agents hold *handles* to knowledge, not knowledge itself, with explicit discipline: pass references + summaries, retrieve when needed, cap at ~2K tokens, offload after completion

## Implementation Details
- All agent context sections follow a consistent 4-part structure (Receives / Loads On-Demand / Produces / Does NOT Pass Forward) for clarity and auditability
- Handoff format uses status tracking (`reference-only | loaded | offloaded`) to prevent context rot across phases
- Violation indicators provide concrete metrics for detecting JIT-C breaches (token counts, history inclusion, context density)
- Changes preserve existing agent responsibilities and version gates while adding explicit context discipline

## Impact
This establishes JIT-C as a **structural requirement**, not a suggestion, preventing context pollution and token waste in multi-phase workflows. Agents now have clear boundaries on what to load, when to load it, and what to exclude from handoffs.

https://claude.ai/code/session_01JVwXGzYwrkbFVVoJncknTY