### PR TITLE
fix: correct SubagentStart/SubagentStop hook nesting structure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,16 +35,24 @@
     ],
     "SubagentStart": [
       {
-        "type": "command",
-        "command": ".claude/hooks/subagent-memory-load.sh $AGENT_NAME",
-        "timeout": 5000
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/subagent-memory-load.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "SubagentStop": [
       {
-        "type": "command",
-        "command": ".claude/hooks/subagent-memory-save.sh $AGENT_NAME",
-        "timeout": 5000
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/subagent-memory-save.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- **SubagentStart/SubagentStop** hooks used a flat array `[{ "type": "command", ... }]` instead of the required three-level nesting `[{ "hooks": [{ "type": "command", ... }] }]` as documented in `HOOK_CONTRACT.md` and used by SessionStart/UserPromptSubmit/Stop
- This caused the hooks to silently fail — Claude Code ignores entries that don't match the expected schema
- Also fixes command path (now uses `$CLAUDE_PROJECT_DIR` + `bash` prefix, matching other hooks) and timeout (5000 → 5, since the value is in seconds per HOOK_CONTRACT.md, not milliseconds)

## Before / After

**Before** (flat — silently ignored):
```json
"SubagentStart": [
  {
    "type": "command",
    "command": ".claude/hooks/subagent-memory-load.sh $AGENT_NAME",
    "timeout": 5000
  }
]
```

**After** (three-level nesting — matches contract):
```json
"SubagentStart": [
  {
    "hooks": [
      {
        "type": "command",
        "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/subagent-memory-load.sh",
        "timeout": 5
      }
    ]
  }
]
```

## Test plan

- [ ] Verify `settings.json` is valid JSON: `python3 -m json.tool .claude/settings.json`
- [ ] Verify nesting matches SessionStart/UserPromptSubmit/Stop structure
- [ ] Start a Claude Code session and confirm SubagentStart hook fires when spawning a subagent

🤖 Generated with [Claude Code](https://claude.com/claude-code)