### PR TITLE
fix: sync ID regex patterns with domain-profile.yaml

### DIFF
--- a/.claude/hooks/context-density-gate.sh
+++ b/.claude/hooks/context-density-gate.sh
@@ -23,7 +23,7 @@ estimate_tokens() {
 
 count_sot_references() {
   local file="$1"
-  grep -oE '\b(BR|UJ|API|CFD|KPI|COMP|UI|ERR|SEC|PERF|TEST)-[0-9]{3}\b' "$file" 2>/dev/null | sort -u | wc -l | tr -d ' '
+  grep -oE '\b(BR|UJ|PER|SCR|API|DBT|TEST|DEP|RUN|MON|CFD|DES|TECH|ARC|INT|FEA|RISK|GTM|KPI|EPIC)-[0-9]{3}\b' "$file" 2>/dev/null | sort -u | wc -l | tr -d ' '
 }
 
 resolve_epic_path() {

--- a/.claude/hooks/sot-update-trigger.sh
+++ b/.claude/hooks/sot-update-trigger.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 
 # Implementation file patterns
 IMPL_EXTENSIONS="py|ts|js|tsx|jsx|go|rs|java|rb"
-SOT_PATTERN='\b(BR|UJ|API|CFD|KPI|COMP|UI|ERR|SEC|PERF|TEST)-[0-9]{3}\b'
+SOT_PATTERN='\b(BR|UJ|PER|SCR|API|DBT|TEST|DEP|RUN|MON|CFD|DES|TECH|ARC|INT|FEA|RISK|GTM|KPI|EPIC)-[0-9]{3}\b'
 
 # --- Helpers ---
 


### PR DESCRIPTION
## Summary

The hardcoded regex in `sot-update-trigger.sh` and `context-density-gate.sh` drifted from the source of truth in `domain-profile.yaml`:

**In regex but NOT in domain-profile.yaml** (removed):
`COMP`, `UI`, `ERR`, `SEC`, `PERF`

**In domain-profile.yaml but NOT in regex** (added):
`PER`, `SCR`, `DBT`, `DEP`, `RUN`, `MON`, `DES`, `TECH`, `ARC`, `INT`, `FEA`, `RISK`, `GTM`, `EPIC`

## Changes

Updated the regex pattern in both files to match all 20 prefixes defined in `domain-profile.yaml`:

```
\b(BR|UJ|PER|SCR|API|DBT|TEST|DEP|RUN|MON|CFD|DES|TECH|ARC|INT|FEA|RISK|GTM|KPI|EPIC)-[0-9]{3}\b
```

## Files changed

- `.claude/hooks/sot-update-trigger.sh` — `SOT_PATTERN` variable
- `.claude/hooks/context-density-gate.sh` — `count_sot_references()` function

## Test plan

- [ ] Verify all 20 prefixes from domain-profile.yaml match the regex
- [ ] Verify removed prefixes (COMP, UI, ERR, SEC, PERF) no longer match
- [ ] `echo '{}' | bash .claude/hooks/sot-update-trigger.sh` still exits cleanly
- [ ] `echo '{}' | bash .claude/hooks/context-density-gate.sh` still exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)