### PR TITLE
Readiness feature

### DIFF
--- a/.claude/rules/07-readiness-protocol.md
+++ b/.claude/rules/07-readiness-protocol.md
@@ -1,0 +1,14 @@
+---
+alwaysApply: true
+---
+
+# Readiness Protocol
+
+- **Three layers**: SoT files (primitive) → EPICs (compose SoT) → PRD stage (composes both). All scores write to `status/readiness.json`.
+- **Compute**: Run `python scripts/readiness.py run` to refresh. Output survives in `status/readiness.json` with `last_computed` timestamp.
+- **Inspect**: `readiness.py status` (text report) or `readiness.py status --json` (machine-readable).
+- **Thresholds**: `score ≥ 70` PASS, `50–69` WARN, `< 50` BLOCK. Exit codes 0/1/2 match.
+- **Inputs**: Declared in `readiness_inputs:` frontmatter — PRD.md for stage scope, `epics/EPIC-XX.md` for epic scope. See `docs/READINESS_PROTOCOL.md` for schema.
+- **Dimension overrides**: Use `dimension_overrides: { confidence_avg: disabled }` per item when the repo hasn't adopted a convention. Disabled dimensions drop; remaining weights renormalize.
+- **Traceability**: EPIC caps cite `caused_by` SoT file; SoT blocks list `consumed_by_epics`. Agents follow the causal chain to find root-cause leverage.
+- **Before advancing gates**: Run readiness. If `summary.current_stage.score < threshold_warn`, update the EPIC and STOP (reinforces rule 05).

--- a/.claude/skills/ghm-gate-check/SKILL.md
+++ b/.claude/skills/ghm-gate-check/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: ghm-gate-check
 description: >
-  Validates gate criteria before PRD lifecycle advancement.
-  Triggers before advancing from v0.X to v0.Y or explicit `/ghm-gate-check` invocation.
-  Outputs pass/block summary with missing artifacts list.
+  Validates gate criteria before PRD lifecycle advancement by delegating to
+  the readiness scoring pipeline (scripts/readiness.py). Returns a graduated
+  PASS / WARN / BLOCK verdict with top blockers and their causal chain.
+  Triggers before advancing from v0.X to v0.Y or explicit `/ghm-gate-check`.
 context: inline
 allowed-tools:
+  - Bash
   - Read
   - Glob
   - Grep
@@ -13,141 +15,135 @@ allowed-tools:
 
 # Gate Check
 
-Validate all gate criteria are met before advancing the PRD lifecycle version.
+Validate whether the PRD stage is ready to advance to the next version. Delegates to the three-layer readiness scorer — SoT files → EPICs → stage — then surfaces the leverage view (what to fix first, and which EPICs it unblocks).
 
 ## Workflow Overview
 
-1. **Load Gate Criteria** → Read target gate requirements from PRD.md
-2. **Verify Evidence** → Check required artifacts exist with valid IDs
-3. **Assess Readiness** → Evaluate handoff requirements
-4. **Report** → Pass/Block with specific gaps
+1. **Compute** → run `scripts/readiness.py run --quiet` to refresh `status/readiness.json`
+2. **Read** → parse `status/readiness.json`
+3. **Report** → PASS / WARN / BLOCK verdict with top blockers and causal links
+4. **Recommend** → actionable next steps (always highest-leverage first)
 
-## Core Output Template
+## Authority
 
-| Element | Definition | Evidence |
-|---------|------------|----------|
-| **Target Gate** | Version being validated | `v0.3 → v0.4` |
-| **Status** | Pass or Block | Clear determination |
-| **Missing Artifacts** | What's not complete | Specific list with IDs |
-| **Recommendation** | Action to take | Proceed / Address gaps |
+`references/gate-criteria.md` remains the canonical source of mandatory artifacts per gate. The scorer's `GATE_REQUIREMENTS` table mirrors it. Do not hand-roll checklists here — the scoring engine is the single source of truth.
 
-## Gate Reference
+## Step 1: Compute
 
-| Gate | Focus | Key Artifacts |
-|------|-------|---------------|
-| v0.1 → v0.2 | Problem validated | CFD-XXX evidence |
-| v0.2 → v0.3 | Market defined | Segment definitions |
-| v0.3 → v0.4 | Commercial viable | BR-XXX, pricing |
-| v0.4 → v0.5 | Journeys mapped | UJ-XXX complete |
-| v0.5 → v0.6 | Risks addressed | Risk register |
-| v0.6 → v0.7 | Architecture set | API-XXX, schemas |
-| v0.7 → v0.8 | Build complete | Tests passing |
-| v0.8 → v0.9 | Deployed | Live environment |
-| v0.9 → v1.0 | Launched | Metrics tracking |
+Run the orchestrator. It runs SoT → EPIC → stage in dependency order and writes `status/readiness.json`.
 
-## Step 1: Load Gate Criteria
+```bash
+python scripts/readiness.py run --quiet
+# exit 0 = all pass, 1 = warn, 2 = block, 3 = error
+```
 
-1. Read PRD.md gate section for target version
-2. Extract all required criteria
-3. Identify artifact types needed (BR, UJ, API, CFD)
+If the exit code is `3`, report a runtime error and stop. If `0/1/2`, proceed to Step 2.
 
-### Checklist
-- [ ] Target gate identified
-- [ ] All criteria extracted
-- [ ] Required artifact types listed
+### Fallback: no scripts available
 
-## Step 2: Verify Evidence
+If `scripts/readiness.py` is missing or Python is unavailable, fall back to reading `status/readiness.json` directly. If that's also absent, report: "Readiness not yet computed — install scripts/requirements.txt and run `python scripts/readiness.py run`."
 
-For each required criterion:
+## Step 2: Read
 
-1. Check artifact exists in SoT/
-2. Verify artifact status is not "Draft"
-3. Confirm cross-references are valid
-4. Check for required CFD-XXX evidence
+```bash
+cat status/readiness.json
+```
 
-### Evidence Matrix
+Extract:
+- `summary.current_stage` — the gate being evaluated and its score
+- `summary.top_blockers` — ranked SoT files blocking progress
+- `stages.{target}` — detailed stage block (dimensions, unmet_criteria, caps)
+- `epics.{id}` — per-EPIC scores (cite the lowest ones)
 
-| Criterion Type | Verification |
-|----------------|--------------|
-| Business Rule | BR-XXX exists, status Active |
-| User Journey | UJ-XXX exists, all steps defined |
-| API Contract | API-XXX exists, endpoints specified |
-| Customer Evidence | CFD-XXX linked to BR-XXX |
+## Step 3: Report
 
-### Checklist
-- [ ] All required BR-XXX verified
-- [ ] All required UJ-XXX verified
-- [ ] All required API-XXX verified
-- [ ] Evidence chain (CFD → BR) validated
-
-## Step 3: Assess Handoff Readiness
-
-Check downstream requirements:
-
-1. Next agent has context needed
-2. No open blockers in current EPIC
-3. Documentation is current
-
-### Checklist
-- [ ] EPIC Session State section has no blockers
-- [ ] README.md is synchronized
-- [ ] Handoff documentation exists
-
-## Step 4: Generate Report
+Use this template. Fill every field from the JSON — do not improvise scores.
 
 ```markdown
-## Gate Check Report: v0.X → v0.Y
+## Gate Check Report: {stage.gate_description}
 
-**Status**: [PASS / BLOCK]
-**Date**: YYYY-MM-DD
+**Verdict**: [PASS | WARN | BLOCK]
+**Stage Score**: {stage.score} / 100  (warn < {threshold_warn}, block < {threshold_block})
+**Date**: {now}
 
-### Criteria Assessment
+### Stage Dimensions
 
-| Criterion | Status | Evidence |
-|-----------|--------|----------|
-| [Criterion 1] | ✅/❌ | [ID or gap] |
-| [Criterion 2] | ✅/❌ | [ID or gap] |
+| Dimension | Score | Weight |
+|-----------|-------|--------|
+| required_ids_present | {score} | {weight} |
+| relevant_sot_readiness | {score} | {weight} |
+| cross_ref_integrity | {score} | {weight} |
+| downstream_epic_readiness | {score or "n/a"} | {weight or "—"} |
 
-### Missing Artifacts
-- [ ] [Specific gap with required action]
+### Top Blockers (leverage view)
+
+1. **{file}** (score {score}) — blocks {N} EPICs: {EPIC-XX, …} — impact {impact}
+2. …
+
+### Unmet Criteria (high severity first)
+
+- [high] {ref}: {reason}
+- [medium] {ref}: {reason}
 
 ### Recommendation
-[Proceed to v0.Y / Address [N] gaps before advancing]
+
+**If PASS**: Advance to {next_version}. Run `ghm-status-sync` to update the README dashboard.
+
+**If WARN / BLOCK**: Do not advance. Address top blockers in order — fixing the highest-impact SoT file cascades up the graph.
+
+**Next action**: {top_blockers[0] → concrete fix}
 ```
+
+### Verdict bands
+
+| Stage score | Verdict | Meaning |
+|---|---|---|
+| ≥ 70 | PASS | Safe to advance |
+| 50–69 | WARN | Advance with documented risk; log in PRD change log |
+| < 50 | BLOCK | Cannot advance — per rule 05-lifecycle-gates, update the EPIC and STOP |
+
+## Step 4: Recommend
+
+Always prioritize by `impact = (100 − score) × #EPICs blocked`. The top blocker is the single highest-leverage fix; cite its `blocking_epics` list so the human understands what unblocks.
 
 ## Quality Gates
 
-### Pass Checklist
-- [ ] All criteria evaluated (none skipped)
-- [ ] Evidence is traceable to IDs
-- [ ] Recommendation is actionable
-
-### Testability Check
-- [ ] Report can be validated against PRD.md criteria
-- [ ] Missing artifacts are specific and findable
+- [ ] Stage score cited from JSON, not estimated
+- [ ] Top blockers include their consumer EPICs
+- [ ] Recommendation is actionable (specific file, specific action)
+- [ ] Verdict matches the score band exactly (don't round up)
 
 ## Anti-Patterns
 
 | Pattern | Example | Fix |
-|---------|---------|-----|
-| Skipping criteria | "Probably fine" | → Verify each explicitly |
-| Vague gaps | "Needs more work" | → Cite specific missing ID |
-| Override blocks | Advancing despite fails | → Address gaps first |
+|---|---|---|
+| Ignoring the score | "Feels ready; pass" | Cite `stage.score` verbatim |
+| Skipping blockers | "Minor stuff, advance anyway" | Block if score < 50; warn if < 70 |
+| Hand-rolling criteria | Re-checking IDs manually | Trust the scorer; if wrong, fix `GATE_REQUIREMENTS` in `_readiness/stage.py` |
+| Forcing PASS | Overriding the verdict | Never override; the score is the contract |
 
 ## Boundaries
 
 **DO**:
-- Validate against documented criteria
-- Identify specific gaps
-- Provide actionable recommendations
+- Delegate computation to `readiness.py`
+- Cite specific scores, files, and EPICs from the JSON
+- Surface the `top_blockers` leverage view
 
 **DON'T**:
-- Create missing artifacts (just report)
-- Override gate blocks
-- Make subjective quality judgments
+- Modify `status/readiness.json` directly — it's computed output
+- Create missing artifacts inside this skill (that's the author's job)
+- Override PASS/BLOCK verdicts subjectively
 
 ## Handoff
 
-After gate check:
-- If PASS: Advance PRD version, trigger `ghm-status-sync`
-- If BLOCK: Return to current stage, address gaps
+After a report:
+- **PASS**: Trigger `ghm-status-sync`; the gate advancement updates the README dashboard
+- **WARN**: Same as PASS but note the risks in the PRD change log
+- **BLOCK**: Return control to the human. The `top_blockers[0]` fix is the single most important next action
+
+## References
+
+- `references/gate-criteria.md` — canonical gate requirements (consumed by scorer)
+- `references/examples.md` — pass/warn/block report examples
+- `.claude/rules/07-readiness-protocol.md` — the discipline rule
+- `docs/READINESS_PROTOCOL.md` — full schema

--- a/.claude/skills/ghm-gate-check/references/examples.md
+++ b/.claude/skills/ghm-gate-check/references/examples.md
@@ -2,6 +2,87 @@
 
 **Purpose**: Good and bad patterns for gate validation with pass/fail scenarios.
 
+> **Note**: As of `ghm-gate-check@evolved-2026-04-17`, verdicts come from `scripts/readiness.py` — a graduated score (0–100) across three layers. The examples below show the JSON-driven report shape; the "Pass/Fail Pattern Summary" at the end covers the *content* patterns (what makes a CFD entry good, what makes a risk actionable).
+
+---
+
+## Graduated-Score Report Example (BLOCK)
+
+**Context**: OriginStamp, evaluating v0.7 → v0.8 transition. `readiness.py run` exits 2.
+
+```markdown
+## Gate Check Report: v0.7 → v0.8 (Build → Deployment)
+
+**Verdict**: BLOCK
+**Stage Score**: 36.6 / 100  (warn < 70, block < 50)
+**Date**: 2026-04-17
+
+### Stage Dimensions
+
+| Dimension | Score | Weight |
+|-----------|-------|--------|
+| required_ids_present | 50.0 | 0.300 |
+| relevant_sot_readiness | 55.4 | 0.300 |
+| cross_ref_integrity | 95.6 | 0.200 |
+| downstream_epic_readiness | 54.3 | 0.200 |
+
+### Top Blockers (leverage view)
+
+1. **SoT/SoT.TESTING.md** (score 0.0) — blocks 8 EPICs: EPIC-01..EPIC-08 — impact 800
+2. **SoT/SoT.API_CONTRACTS.md** (score 55.8) — blocks 7 EPICs: EPIC-02..EPIC-08 — impact 309
+3. **SoT/SoT.USER_JOURNEYS.md** (score 0.0) — blocks 1 EPIC: EPIC-07 — impact 100
+
+### Unmet Criteria (high severity first)
+
+- [high] TEST: Found 0 TEST- entries; gate requires ≥1
+- [high] SoT/SoT.TESTING.md scores 0.0 — drags down stage readiness
+- [high] 7 dangling ID reference(s) across repo: TEST-008, UJ-001, UJ-002, …
+
+### Recommendation
+
+Do not advance. Address top blockers in order — fixing the highest-impact SoT file cascades up the graph.
+
+**Next action**: Populate SoT.TESTING.md with TEST- entries covering every API-/BR- in scope. Unblocks all 8 EPICs at once.
+```
+
+The power here is in the leverage view: 8 EPICs at WARN suggests 8 problems; the connected scorer reveals 1 root cause (empty `SoT.TESTING.md`). That's the fix-first action.
+
+---
+
+## Graduated-Score Report Example (PASS)
+
+**Context**: Hypothetical mature repo advancing v0.6 → v0.7. Score 84.
+
+```markdown
+## Gate Check Report: v0.6 → v0.7 (Architecture → Build)
+
+**Verdict**: PASS
+**Stage Score**: 84.0 / 100  (warn < 70, block < 50)
+
+### Stage Dimensions
+
+| Dimension | Score | Weight |
+|-----------|-------|--------|
+| required_ids_present | 100.0 | 0.375 |
+| relevant_sot_readiness | 82.3 | 0.375 |
+| cross_ref_integrity | 98.0 | 0.250 |
+| downstream_epic_readiness | n/a | — |
+
+### Top Blockers
+
+None — all SoT files passing.
+
+### Recommendation
+
+Advance to v0.7. Run `ghm-status-sync` to update the README dashboard.
+```
+
+---
+
+## Content Patterns — Good vs Bad Artifacts
+
+The scorer enforces structure (IDs exist, files are populated, refs resolve). The patterns below cover *content quality* — what makes individual artifacts good, which is still a human judgment the scorer can't fully automate.
+
 ---
 
 ## Good Example: v0.2 → v0.3 Gate Pass

--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -1,0 +1,36 @@
+name: Readiness
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt
+      - name: Run pytest
+        run: python -m pytest tests/ -v
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r scripts/requirements.txt
+      - name: Repo self-scoring (non-blocking)
+        # Score the repo itself. Continues on non-zero exit so a WARN/BLOCK
+        # on PRD-CE's own state doesn't fail CI — the tests job already
+        # validates the scoring engine. This step is a self-dogfooding check
+        # that surfaces the score in the Actions log.
+        continue-on-error: true
+        run: python scripts/readiness.py run || true

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ out/
 # Visualization Suite Python cache
 __pycache__/
 *.pyc
+
+# Readiness scoring — generated output, not source
+status/readiness.json
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -142,6 +142,43 @@ This layer orients attention and sets priorities. Files load in stable→volatil
 
 ---
 
+<!-- SECTION: readiness-scoring -->
+## Readiness Scoring
+
+The ecosystem is self-assessing. Before advancing a stage or starting an EPIC, the repo knows whether it's ready — and why.
+
+Readiness scoring is a **three-layer graph** over the artifacts you already author:
+
+1. **SoT files** — the primitive. Each file is scored on entry count, depth, cross-reference density, and orphan rate. A placeholder `SoT.TESTING.md` scores 0.
+2. **EPICs** — composed from SoT scores. An EPIC inherits the readiness of every file it references via its Section 3 "Context & IDs". Dangling refs, empty test files, or unresolved assumptions surface as unmet criteria. Each cap cites the SoT file that caused it.
+3. **PRD stage** — composed from both. Answers "can we advance v0.X → v0.Y?" by checking gate-criteria's mandatory artifacts plus the relevant SoT and EPIC scores.
+
+All three layers write to one file: `status/readiness.json`. The causal links stay in the JSON — an EPIC's unmet criterion points at its `caused_by` SoT file; a SoT file's block lists its `consumed_by_epics`; the top-level `summary.top_blockers` ranks files by downstream impact. This is the leverage view: the highest-impact fix might not be the lowest-scoring file — it's the lowest-scoring file blocking the most EPICs.
+
+### Invocation
+
+```bash
+python scripts/readiness.py run        # compute all layers + print report
+python scripts/readiness.py status     # print last-computed report
+python scripts/readiness.py run --json # machine-readable output for hooks/CI
+```
+
+Exit codes: `0` all pass, `1` something in WARN band, `2` something in BLOCK band. Thresholds default to warn=70, block=50 and can be overridden per-item in `readiness_inputs:` frontmatter.
+
+### Where scores show up
+
+- `status/readiness.json` — the single machine-readable source.
+- `readiness.py`'s text report — one-page "what to fix first" output.
+- `ghm-gate-check` skill — delegates to `readiness.py` for stage-advancement decisions (rule 05 still applies: if WARN or BLOCK, update the EPIC and STOP).
+
+### Deeper reading
+
+- [`.claude/rules/07-readiness-protocol.md`](.claude/rules/07-readiness-protocol.md) — the discipline rule.
+- [`docs/READINESS_PROTOCOL.md`](docs/READINESS_PROTOCOL.md) — full schema reference: `readiness_inputs` YAML shape, `readiness.json` structure, every dimension with its formula, penalty math, critical caps, and how to extend it.
+<!-- /SECTION: readiness-scoring -->
+
+---
+
 <!-- SECTION: lifecycle -->
 ## The Progressive PRD
 

--- a/docs/READINESS_PROTOCOL.md
+++ b/docs/READINESS_PROTOCOL.md
@@ -1,0 +1,380 @@
+# Readiness Protocol — Schema Reference
+
+**Status**: v1.0 · schema_version `1.0` · last revised 2026-04-17
+
+Readiness scoring tells you — at three levels of granularity — whether work in a PRD-CE repo is ready to advance. This document is the canonical schema reference. For the discipline rule see `.claude/rules/07-readiness-protocol.md`; for narrative context see the README's "Readiness Scoring" section.
+
+---
+
+## 1. Overview
+
+Three composable scorers write to one file:
+
+| Layer | Answers | Reads | Writes to `status/readiness.json` |
+|---|---|---|---|
+| **SoT file** (primitive) | "Is `SoT.X.md` in good shape?" | SoT files, domain profile | `sot_files.{path}` |
+| **EPIC** (middle) | "Can we build this EPIC?" | SoT file scores, EPIC frontmatter + Section 3 | `epics.{EPIC-ID}` |
+| **PRD stage** (composer) | "Can we advance v0.X → v0.Y?" | SoT file + EPIC scores, gate requirements | `stages.{v0.X}` |
+
+The orchestrator `scripts/readiness.py` runs all three in dependency order (SoT → EPIC → stage) and produces a single text report + machine-readable JSON.
+
+### File roles
+
+| File | Role | Who writes |
+|---|---|---|
+| `PRD.md` (per-stage `readiness_inputs`) | Declared inputs: threshold overrides, dimension overrides | Human |
+| `epics/EPIC-XX.md` (frontmatter `readiness_inputs`) | Declared inputs: dependencies, thresholds, overrides | Human |
+| `epics/EPIC-XX.md` Section 3 "Context & IDs" | Referenced IDs the EPIC needs | Human |
+| `.claude/domain-profile.yaml` | ID prefix → owning SoT file mapping | Human (stable) |
+| `status/readiness.json` | All computed scores, causal links, summaries | Scorers (volatile) |
+
+PRD.md stays diff-friendly — computed scores never write back to it. The JSON is the single sync target.
+
+---
+
+## 2. `readiness_inputs` frontmatter schema
+
+### EPIC scope (`epics/EPIC-XX.md`)
+
+```yaml
+---
+template_version: "3.3.0"
+readiness_inputs:
+  work_type: epic              # required
+  depends_on_epics: []         # list of EPIC-IDs that must be Complete before this can build
+  required_tests: auto         # auto = derived from Section 3 API-/BR- IDs; or explicit list [TEST-010, TEST-011]
+  context_budget:              # optional; surfaces in downstream agent pre-load planning
+    preload: 40000
+    working_room: 160000
+  threshold_warn: 70           # default 70
+  threshold_block: 50          # default 50
+  dimension_overrides: {}      # e.g. { confidence_avg: disabled, status_maturity: disabled }
+---
+```
+
+Authoring rules:
+- Do **not** include `required_specs:` — the scorer parses EPIC Section 3 directly. Maintaining a duplicate list causes drift.
+- `work_type: epic` is required so the scorer picks the right scoring function.
+- `dimension_overrides` values are `enabled` (default) or `disabled`. Disabled dimensions drop from the weighted sum; remaining weights renormalize to 1.0.
+
+### Stage scope (`PRD.md`, embedded per-stage block)
+
+```yaml
+readiness_inputs:
+  target_gate: "v0.6 → v0.7"   # optional — scorer autodetects from PRD.md "Next Target Gate"
+  confidence_floor: 3          # minimum 1–5 confidence if the repo uses confidence fields
+  threshold_warn: 70
+  threshold_block: 50
+  weight_overrides:            # optional; renormalized with universal defaults
+    cross_ref_integrity: 0.30
+```
+
+The scorer reads the target gate from `PRD.md`'s "Next Target Gate" field if `target_gate` is not explicitly declared.
+
+---
+
+## 3. `status/readiness.json` structure
+
+### Top-level
+
+```json
+{
+  "last_computed": "2026-04-17T08:23:21.062830+00:00",
+  "computed_by": "compute-prd-readiness@0.1.0",
+  "schema_version": "1.0",
+  "sot_files": { "...": { /* SoT block */ } },
+  "epics":     { "...": { /* EPIC block */ } },
+  "stages":    { "...": { /* Stage block */ } },
+  "summary":   { /* see §6 */ }
+}
+```
+
+Fields written by whichever scorer ran last — `computed_by` reflects the final writer. `schema_version` bumps on breaking shape changes.
+
+### SoT file block
+
+```json
+{
+  "target": "SoT/SoT.API_CONTRACTS.md",
+  "work_type": "sot",
+  "score": 55.8,
+  "weighted_score": 69.8,
+  "penalty": 14,
+  "cap_applied": null,
+  "caps": [],
+  "entry_count": 28,
+  "consumed_by_epics": ["EPIC-02", "EPIC-03", "..."],
+  "dimensions": {
+    "entry_count":         { "score": 100.0, "weight": 0.200 },
+    "entry_depth":         { "score":  89.3, "weight": 0.333 },
+    "cross_ref_density":   { "score":   0.0, "weight": 0.267 },
+    "orphan_rate":         { "score": 100.0, "weight": 0.200 },
+    "status_coverage":     { "status": "not_applicable" },
+    "confidence_coverage": { "status": "not_applicable" }
+  },
+  "unmet_criteria": [ /* see §5 */ ]
+}
+```
+
+### EPIC block
+
+```json
+{
+  "target": "EPIC-01",
+  "work_type": "epic",
+  "state": "Planned",
+  "score": 55.0,
+  "weighted_score": 81.2,
+  "penalty": 10,
+  "cap_applied": 55,
+  "caps": [
+    {
+      "rule": "test_coverage_zero",
+      "cap": 55,
+      "reason": "test_coverage_declared is 0 — v0.7 requires TEST- entries before build.",
+      "caused_by": "SoT/SoT.TESTING.md",
+      "caused_by_score": 0.0
+    }
+  ],
+  "threshold_warn": 70,
+  "threshold_block": 50,
+  "dimensions": { /* see §4 */ },
+  "unmet_criteria": [ /* see §5 */ ],
+  "referenced_ids_count": 29,
+  "file": "epics/EPIC-01-project-infrastructure.md"
+}
+```
+
+### Stage block
+
+```json
+{
+  "target": "v0.8",
+  "work_type": "stage",
+  "gate_description": "v0.7 → v0.8 (Build → Deployment)",
+  "score": 36.6,
+  "weighted_score": 61.6,
+  "penalty": 25,
+  "cap_applied": null,
+  "caps": [],
+  "threshold_warn": 70,
+  "threshold_block": 50,
+  "dimensions": { /* see §4 */ },
+  "unmet_criteria": [ /* see §5 */ ]
+}
+```
+
+---
+
+## 4. Dimensions (all layers)
+
+Each dimension scores 0–100. Dimensions that can't be evaluated (e.g. no Confidence fields exist in the repo) auto-mark `"status": "not_applicable"` and their weight redistributes.
+
+### SoT file dimensions
+
+| Dimension | Weight | What it measures |
+|---|---:|---|
+| `entry_count` | 0.15 | Populated (≥3 entries) vs. sparse vs. placeholder. Placeholder files (no entries + "pending"/"todo"/"placeholder" marker) score 0. |
+| `entry_depth` | 0.25 | Percentage of entries ≥15 words AND containing a structural keyword (`rationale`, `request`, `response`, `fields`, `step`, etc.). Catches stub templates. |
+| `cross_ref_density` | 0.20 | Percentage of entries referencing at least one other ID in their body. Isolated entries are weak knowledge-graph nodes. |
+| `orphan_rate` | 0.15 | Percentage of entries cited somewhere outside their own SoT file. Never-referenced entries are dead weight. |
+| `status_coverage` | 0.10 | Percentage with a `Status:` field. Auto-disabled if zero entries have it (repo doesn't use the convention). |
+| `confidence_coverage` | 0.15 | Percentage with a `Confidence: N/5` field. Auto-disabled if zero entries have it. |
+
+### EPIC dimensions
+
+| Dimension | Weight | What it measures |
+|---|---:|---|
+| `spec_resolution` | 0.20 | Percentage of Section 3 referenced IDs that resolve to a definition. Dangling IDs = high-severity unmet. |
+| `spec_depth` | 0.15 | Percentage of resolved IDs that pass the non-stub heuristic. |
+| `test_coverage_declared` | 0.15 | For each API-/BR- in scope, does a TEST- entry reference it back? Enforces v0.7 test-first methodology. |
+| `upstream_gate` | 0.10 | Is the owning stage's score above threshold? Inherits stage readiness. |
+| `dependency_readiness` | 0.10 | Percentage of `depends_on_epics` in State = Complete. |
+| `ambiguity_load` | 0.05 | Unresolved rows in Session State → Assumptions & Ambiguities log. 20-point deduction each. |
+| `confidence_avg` | 0.15 | Mean confidence of referenced IDs (scaled to 0–100). Auto-disabled if no Confidence fields found. |
+| `status_maturity` | 0.05 | Percentage of resolved IDs with `Status ≠ Draft`. Auto-disabled if no Status fields found. |
+| `file_readiness` | 0.05 | Percentage of SoT files the EPIC depends on that contain real entries (not placeholders). Catches `SoT.USER_JOURNEYS.md: *Pending PRD development*` cases. |
+
+### Stage dimensions
+
+| Dimension | Weight | What it measures |
+|---|---:|---|
+| `required_ids_present` | 0.30 | Fraction of gate-mandated prefixes meeting their minimum count. Sourced from `GATE_REQUIREMENTS` in `_readiness/stage.py` (mirrors `.claude/skills/ghm-gate-check/references/gate-criteria.md`). |
+| `relevant_sot_readiness` | 0.30 | Weighted mean of SoT file scores for files this gate depends on. |
+| `cross_ref_integrity` | 0.20 | Percentage of known-prefix ID references across the repo that resolve. False-positive-resistant (only counts prefixes in `domain-profile.yaml`). |
+| `downstream_epic_readiness` | 0.20 | For v0.7+ gates: mean EPIC score. Auto-disabled for pre-v0.7 gates. |
+
+---
+
+## 5. `unmet_criteria` entry shape
+
+Each item in an `unmet_criteria` list:
+
+```json
+{
+  "dimension": "spec_resolution",
+  "ref": "UJ-001",
+  "reason": "UJ-001 referenced in EPIC Section 3 but not defined in any SoT/PRD file.",
+  "severity": "high",
+  "caused_by": "SoT/SoT.USER_JOURNEYS.md",
+  "caused_by_score": 0.0,
+  "fix": "Define UJ-001 in its SoT file, or remove the reference from Section 3."
+}
+```
+
+- **severity**: `high`, `medium`, `low` — drives penalty size (see §7).
+- **caused_by**: path of the SoT file implicated. Set for dimensions whose failure is attributable to a single file.
+- **caused_by_score**: SoT file's current score. Lets consumers rank by leverage.
+- **fix**: short actionable suggestion, not a tutorial.
+- **ref**: the specific ID or file the criterion concerns. Optional; dimension-level issues (e.g. too many dangling refs overall) omit it.
+
+---
+
+## 6. `summary` block
+
+Produced by every scorer run; always reflects the current `readiness.json` state.
+
+```json
+{
+  "sot_files_total": 11,
+  "sot_files_passing": 4,
+  "epics_total": 8,
+  "epics_passing": 0,
+  "threshold": 70,
+  "top_blockers": [
+    {
+      "file": "SoT/SoT.TESTING.md",
+      "score": 0.0,
+      "blocks": 8,
+      "blocking_epics": ["EPIC-01", "EPIC-02", "..."],
+      "impact": 800
+    }
+  ],
+  "current_stage": { "target": "v0.8", "score": 36.6, "passing": false }
+}
+```
+
+`impact = (100 − score) × blocks`. Ranks SoT files by the aggregate pain they cause — the "fix this first" list.
+
+---
+
+## 7. Scoring formula
+
+```
+weighted_score = Σ (dimension_score × dimension_weight)
+                 over enabled dimensions (weights renormalize to 1.0)
+
+raw_penalty    = Σ SEVERITY_PENALTY[c.severity] for c in unmet_criteria
+penalty        = min(raw_penalty, MAX_PENALTY = 25)
+
+cap            = min(100, each CRITICAL_CAP triggered by dimension state)
+
+final_score    = min(cap, max(0, weighted_score − penalty))
+```
+
+**Constants** (in `scripts/_readiness/common.py`):
+
+| Constant | Value | Purpose |
+|---|---|---|
+| `SEVERITY_PENALTY.high` | 10 | Per high-severity unmet |
+| `SEVERITY_PENALTY.medium` | 3 | Per medium-severity unmet |
+| `SEVERITY_PENALTY.low` | 1 | Per low-severity unmet |
+| `MAX_PENALTY` | 25 | Prevents pile-ons from crushing scores |
+
+**Critical caps** (EPIC):
+
+| Rule | Cap | Trigger |
+|---|---|---|
+| `test_coverage_zero` | 55 | `test_coverage_declared == 0` and EPIC references any API-/BR-. |
+| `spec_resolution_low` | 60 | `spec_resolution < 80%` — too many dangling IDs. |
+| `stub_sot_file` | 60 | Any SoT file the EPIC depends on is a placeholder stub. |
+
+**Critical caps** (Stage):
+
+| Rule | Cap | Trigger |
+|---|---|---|
+| `missing_mandatory_artifacts` | 45 | `required_ids_present < 50%` — gate cannot pass regardless of other signals. |
+| `cross_ref_broken` | 60 | `cross_ref_integrity < 60%` — repo integrity compromised. |
+
+**Critical caps** (SoT):
+
+| Rule | Cap | Trigger |
+|---|---|---|
+| `placeholder_file` | 10 | No entries + placeholder marker in body. |
+| `nearly_empty` | 40 | 1–2 entries but file is referenced externally. |
+
+---
+
+## 8. Weights — defaults and overrides
+
+**Universal defaults** live in `scripts/_readiness/common.py` (per-layer constants). Per-gate overrides live in `PRD.md`'s `readiness_inputs.weight_overrides` for the stage in question. Overrides merge with defaults; renormalization ensures sum = 1.0.
+
+**When to override**:
+- v0.1 evidence-heavy gates → boost `cross_ref_integrity` or confidence-tier weight.
+- v0.8 test-coverage-heavy gates → boost `test_coverage_declared` (EPIC layer).
+- Project-wide preference → set in `.claude/readiness-config.yaml` (optional repo-level file).
+
+**When not to override**: if the default is "close enough," leave it. Overrides are easy to forget and drift; the universal defaults intentionally cover ~80% of cases.
+
+---
+
+## 9. Invocation
+
+```bash
+# Compute all three layers, print text report, exit with pass/warn/block code
+python scripts/readiness.py run
+
+# Print report from existing readiness.json without recomputing
+python scripts/readiness.py status
+
+# Emit raw JSON instead of text
+python scripts/readiness.py run --json
+
+# CI-friendly: suppress output, exit code only
+python scripts/readiness.py run --quiet
+
+# Override target gate
+python scripts/readiness.py run --gate v0.7
+
+# Run one layer at a time (for debugging)
+python scripts/compute-sot-readiness.py all
+python scripts/compute-readiness.py epics/EPIC-01.md --merge
+python scripts/compute-prd-readiness.py --gate v0.8
+```
+
+**Exit codes** (from `readiness.py`):
+
+| Code | Meaning |
+|---|---|
+| 0 | All items (stages, EPICs, SoT files) scored ≥ `threshold_warn`. |
+| 1 | At least one item in WARN band (`threshold_block` ≤ score < `threshold_warn`). |
+| 2 | At least one item in BLOCK band (score < `threshold_block`). |
+| 3 | Runtime error (missing files, invalid inputs, etc.). |
+
+---
+
+## 10. Interpreting the report
+
+Read the report top-to-bottom as a causal chain:
+
+1. **Stage** tells you whether the repo can advance. If BLOCK, the next question is *why*.
+2. **EPICs** tell you which work packages are blocked. Each cap cites its `caused_by` SoT file.
+3. **SoT files** tell you the root cause. The `top_blockers` list orders files by leverage — fixing the top item unblocks the most EPICs.
+
+The `NEXT ACTIONS` section translates the leverage view into a punch list — highest-impact first. An author's workflow is typically: fix #1, re-run `readiness.py run`, fix #2, etc. The stage score rises as SoT files rise.
+
+---
+
+## 11. Extending the schema
+
+When adding a new dimension:
+1. Add the dimension function in the relevant `_readiness/{sot|epic|stage}.py` module — signature `(ctx, index, ...) -> tuple[Optional[float], list[dict]]`.
+2. Add weight to the corresponding `_WEIGHTS` constant in `common.py`, ensuring weights still sum to 1.0 when all enabled.
+3. Update this schema doc (§4) with the dimension row.
+4. Add a smoke test in `tests/test_readiness.py`.
+5. Bump `SCHEMA_VERSION` in `common.py` if existing consumers would break.
+
+When adding a critical cap:
+1. Add the trigger logic + cap value in the layer's compute function.
+2. Document in §7.
+3. Add a smoke test that verifies the cap triggers under the expected condition.

--- a/epics/EPIC_TEMPLATE.md
+++ b/epics/EPIC_TEMPLATE.md
@@ -1,5 +1,13 @@
 ---
-template_version: "3.2.0"
+template_version: "3.3.0"
+readiness_inputs:
+  work_type: epic
+  depends_on_epics: []
+  required_tests: auto
+  context_budget: { preload: 40000, working_room: 160000 }
+  threshold_warn: 70
+  threshold_block: 50
+  dimension_overrides: {}
 ---
 
 # EPIC-{NUMBER} {EPIC NAME}
@@ -145,7 +153,8 @@ After research/design phases complete, the coordinator MUST produce:
 <!-- SECTION: change-log -->
 ## Change Log
 
-| Date       | Agent  | Action       |
-| ---------- | ------ | ------------ |
-| YYYY-MM-DD | {Name} | Created EPIC |
+| Date       | Agent  | Action                                                                        |
+| ---------- | ------ | ----------------------------------------------------------------------------- |
+| 2026-04-17 | —      | Template 3.3.0: added `readiness_inputs` frontmatter for readiness scoring    |
+| YYYY-MM-DD | {Name} | Created EPIC                                                                  |
 <!-- /SECTION: change-log -->

--- a/scripts/_readiness/__init__.py
+++ b/scripts/_readiness/__init__.py
@@ -1,0 +1,16 @@
+"""PRD-CE readiness scoring package.
+
+Three layers compose into `status/readiness.json`:
+
+    SoT files  (primitive)  —  _readiness.sot
+    EPICs      (middle)     —  _readiness.epic   (reads SoT scores)
+    PRD stage  (composer)   —  _readiness.stage  (reads SoT + EPIC scores)
+
+Shared primitives (SoTEntry, index_all_entries, domain profile loading,
+severity constants, build_summary) live in `_readiness.common`.
+
+See docs/READINESS_PROTOCOL.md for the full schema.
+"""
+
+VERSION = "0.2.0"
+SCHEMA_VERSION = "1.0"

--- a/scripts/_readiness/common.py
+++ b/scripts/_readiness/common.py
@@ -1,0 +1,327 @@
+"""Shared primitives for readiness scoring.
+
+Everything that sot.py, epic.py, and stage.py all need lives here so the
+three modules can stay focused on their own scoring logic.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+# ---------- Regex / token constants ---------- #
+
+ID_RE = re.compile(r"\b([A-Z]{2,5})-(\d{2,3})\b")
+# Range syntax: "ENT-001 → ENT-014" or "..", "to"
+RANGE_RE = re.compile(
+    r"\b([A-Z]{2,5})-(\d{2,3})\s*(?:\u2192|->|\.\.|to)\s*(?:[A-Z]{2,5}-)?(\d{2,3})\b"
+)
+HEADING_DEF_RE = re.compile(r"^#{2,3}\s+([A-Z]{2,5}-\d{2,3})\b")
+CONFIDENCE_RE = re.compile(r"Confidence:\s*(\d)\s*/\s*5", re.IGNORECASE)
+STATUS_RE = re.compile(r"^\s*-?\s*\*?\*?Status\*?\*?:\s*([A-Za-z][\w-]*)", re.MULTILINE)
+SECTION_HEADING_RE = re.compile(r"^#{1,3}\s+", re.MULTILINE)
+
+PLACEHOLDER_MARKERS = (
+    "pending prd development", "todo", "placeholder", "to be filled", "tbd",
+)
+
+STUB_KEYWORDS = (
+    "rationale", "purpose", "description", "alternative", "request",
+    "response", "fields", "columns", "step", "given", "when", "then",
+    "decision", "constraint", "type", "title",
+)
+
+
+# ---------- Severity / penalty constants ---------- #
+
+SEVERITY_PENALTY = {"high": 10, "medium": 3, "low": 1}
+MAX_PENALTY = 25
+
+
+# ---------- SoT entry ---------- #
+
+@dataclass
+class SoTEntry:
+    """One ID definition found under a `## ID-NNN` or `### ID-NNN` heading."""
+    id: str
+    prefix: str
+    file: str
+    line: int
+    body: str
+
+    def word_count(self) -> int:
+        return len(self.body.split())
+
+    def is_non_stub(self) -> bool:
+        if self.word_count() < 15:
+            return False
+        lower = self.body.lower()
+        return any(kw in lower for kw in STUB_KEYWORDS)
+
+    def confidence(self) -> Optional[int]:
+        m = CONFIDENCE_RE.search(self.body)
+        return int(m.group(1)) if m else None
+
+    def status(self) -> Optional[str]:
+        m = STATUS_RE.search(self.body)
+        return m.group(1) if m else None
+
+    def has_status(self) -> bool:
+        return self.status() is not None
+
+    def has_confidence(self) -> bool:
+        return self.confidence() is not None
+
+    def outbound_refs(self) -> set[str]:
+        """IDs referenced in this entry's body, excluding self."""
+        refs = {f"{m.group(1)}-{m.group(2)}" for m in ID_RE.finditer(self.body)}
+        refs.discard(self.id)
+        return refs
+
+
+# ---------- Domain profile ---------- #
+
+# Fallback prefix → owning file mapping when a repo has no domain-profile.yaml.
+# Covers the canonical PRD-CE taxonomy. Repo-specific profiles override.
+DEFAULT_ID_PREFIXES = {
+    "BR":   {"file": "SoT/SoT.BUSINESS_RULES.md"},
+    "UJ":   {"file": "SoT/SoT.USER_JOURNEYS.md"},
+    "PER":  {"file": "SoT/SoT.USER_JOURNEYS.md"},
+    "SCR":  {"file": "SoT/SoT.USER_JOURNEYS.md"},
+    "API":  {"file": "SoT/SoT.API_CONTRACTS.md"},
+    "DBT":  {"file": "SoT/SoT.DATA_MODEL.md"},
+    "ENT":  {"file": "SoT/SoT.DATA_MODEL.md"},
+    "TEST": {"file": "SoT/SoT.TESTING.md"},
+    "DEP":  {"file": "SoT/SoT.DEPLOYMENT.md"},
+    "RUN":  {"file": "SoT/SoT.DEPLOYMENT.md"},
+    "MON":  {"file": "SoT/SoT.DEPLOYMENT.md"},
+    "CFD":  {"file": "SoT/SoT.customer_feedback.md"},
+    "DES":  {"file": "SoT/SoT.DESIGN_COMPONENTS.md"},
+    "TECH": {"file": "SoT/SoT.TECHNICAL_DECISIONS.md"},
+    "ARC":  {"file": "SoT/SoT.TECHNICAL_DECISIONS.md"},
+    "INT":  {"file": "SoT/SoT.INTEGRATIONS.md"},
+    "RISK": {"file": "SoT/SoT.RISKS.md"},
+    "FEA":  {"file": "PRD.md"},
+}
+
+
+def load_domain_profile(repo: Path) -> dict:
+    """Load `.claude/domain-profile.yaml` merged on top of DEFAULT_ID_PREFIXES."""
+    path = repo / ".claude" / "domain-profile.yaml"
+    result = dict(DEFAULT_ID_PREFIXES)
+    if path.is_file():
+        with path.open() as f:
+            data = yaml.safe_load(f) or {}
+        repo_prefixes = data.get("id_prefixes") or {}
+        result.update(repo_prefixes)
+    return result
+
+
+def load_readiness_config(repo: Path) -> dict:
+    """Optional repo-level overrides — per-dimension defaults, etc."""
+    path = repo / ".claude" / "readiness-config.yaml"
+    if not path.is_file():
+        return {}
+    with path.open() as f:
+        return yaml.safe_load(f) or {}
+
+
+# ---------- Repo discovery ---------- #
+
+def find_repo_root(start: Path) -> Path:
+    """Walk up from `start` until a PRD.md / SoT/ / epics/ is found."""
+    p = start.resolve()
+    if p.is_file():
+        p = p.parent
+    while p != p.parent:
+        if (p / "PRD.md").is_file() or (p / "SoT").is_dir() or (p / "epics").is_dir():
+            return p
+        p = p.parent
+    raise SystemExit(f"error: could not find repo root above {start}")
+
+
+# ---------- Frontmatter parsing ---------- #
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    """Extract YAML frontmatter. Returns (dict, body-without-frontmatter)."""
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    fm_text = text[4:end]
+    body = text[end + 5:]
+    try:
+        data = yaml.safe_load(fm_text) or {}
+    except yaml.YAMLError:
+        data = {}
+    return data, body
+
+
+# ---------- Section extraction / ID ranges ---------- #
+
+def extract_section(body: str, heading_regex: str) -> Optional[str]:
+    """Return the text of a section between heading_regex and the next ## heading."""
+    matches = list(re.finditer(heading_regex, body, re.MULTILINE))
+    if not matches:
+        return None
+    start = matches[0].end()
+    next_section = re.search(r"^#{1,2}\s+", body[start:], re.MULTILINE)
+    end = start + next_section.start() if next_section else len(body)
+    return body[start:end]
+
+
+def expand_ranges(text: str) -> set[str]:
+    """Find 'ENT-001 → ENT-014' style ranges and return the expanded IDs."""
+    out: set[str] = set()
+    for m in RANGE_RE.finditer(text):
+        prefix = m.group(1)
+        start = int(m.group(2))
+        end = int(m.group(3))
+        if end < start:
+            start, end = end, start
+        digits = max(len(m.group(2)), len(m.group(3)))
+        for n in range(start, end + 1):
+            out.add(f"{prefix}-{str(n).zfill(digits)}")
+    return out
+
+
+# ---------- Entry indexing ---------- #
+
+def index_all_entries(repo: Path) -> dict[str, SoTEntry]:
+    """Scan SoT/, PRD.md, epics/ for `## ID-NNN` / `### ID-NNN` definitions.
+
+    The body for each entry runs from its heading to the next heading at
+    depth 1–3. Collects all entries into `{id: SoTEntry}`.
+    """
+    index: dict[str, SoTEntry] = {}
+    files: list[Path] = []
+
+    sot_dir = repo / "SoT"
+    if sot_dir.is_dir():
+        files.extend(p for p in sot_dir.glob("*.md")
+                     if p.name not in {"SoT.README.md", "SoT.UNIQUE_ID_SYSTEM.md"})
+    for extra in ("PRD.md", "README.md"):
+        p = repo / extra
+        if p.is_file():
+            files.append(p)
+    epics_dir = repo / "epics"
+    if epics_dir.is_dir():
+        files.extend(p for p in epics_dir.glob("*.md") if p.name != "EPIC_TEMPLATE.md")
+
+    for f in files:
+        text = f.read_text(errors="replace")
+        lines = text.splitlines()
+        current: Optional[SoTEntry] = None
+        body_lines: list[str] = []
+        for i, line in enumerate(lines, start=1):
+            m = HEADING_DEF_RE.match(line)
+            if m:
+                if current is not None:
+                    current.body = "\n".join(body_lines).strip()
+                    index.setdefault(current.id, current)
+                id_ = m.group(1)
+                prefix = id_.split("-")[0]
+                current = SoTEntry(id=id_, prefix=prefix,
+                                   file=str(f.relative_to(repo)), line=i, body="")
+                body_lines = []
+            elif current is not None:
+                if SECTION_HEADING_RE.match(line):
+                    current.body = "\n".join(body_lines).strip()
+                    index.setdefault(current.id, current)
+                    current = None
+                    body_lines = []
+                else:
+                    body_lines.append(line)
+        if current is not None:
+            current.body = "\n".join(body_lines).strip()
+            index.setdefault(current.id, current)
+    return index
+
+
+def collect_all_references(repo: Path) -> dict[str, set[str]]:
+    """Return `{id: {files_that_reference_it}}` across SoT/, epics/, PRD, README, CLAUDE.
+
+    Used by orphan-rate scoring — an entry defined in SoT.X but referenced only
+    within SoT.X is orphaned.
+    """
+    refs: dict[str, set[str]] = {}
+    roots: list[Path] = []
+    for sub in ("SoT", "epics"):
+        p = repo / sub
+        if p.is_dir():
+            roots.extend(p.glob("*.md"))
+    for extra in ("PRD.md", "README.md", "CLAUDE.md"):
+        p = repo / extra
+        if p.is_file():
+            roots.append(p)
+
+    for f in roots:
+        rel = str(f.relative_to(repo))
+        text = f.read_text(errors="replace")
+        seen: set[str] = set()
+        for m in ID_RE.finditer(text):
+            seen.add(f"{m.group(1)}-{m.group(2)}")
+        for id_ in seen:
+            refs.setdefault(id_, set()).add(rel)
+    return refs
+
+
+# ---------- Summary / blockers ---------- #
+
+def build_summary(output: dict, threshold: int = 70) -> dict:
+    """Aggregate view: counts + top blockers ranked by EPIC impact.
+
+    Called by every scorer on write, so the top-level `summary` block
+    is always current regardless of which layer ran last.
+    """
+    sot_files = output.get("sot_files", {}) or {}
+    epics = output.get("epics", {}) or {}
+    stages = output.get("stages", {}) or {}
+
+    sot_passing = sum(1 for b in sot_files.values() if b.get("score", 0) >= threshold)
+    epic_passing = sum(1 for b in epics.values() if b.get("score", 0) >= threshold)
+
+    # Rank SoT files by (100 − score) × #consumers. Higher impact = worse blocker.
+    blockers = []
+    for path, block in sot_files.items():
+        if block.get("score", 0) >= threshold:
+            continue
+        consumers = block.get("consumed_by_epics", [])
+        if not consumers:
+            continue
+        impact = (100 - block.get("score", 0)) * len(consumers)
+        blockers.append({
+            "file": path,
+            "score": block.get("score", 0),
+            "blocks": len(consumers),
+            "blocking_epics": consumers,
+            "impact": round(impact, 0),
+        })
+    blockers.sort(key=lambda b: -b["impact"])
+
+    summary = {
+        "sot_files_total": len(sot_files),
+        "sot_files_passing": sot_passing,
+        "epics_total": len(epics),
+        "epics_passing": epic_passing,
+        "threshold": threshold,
+        "top_blockers": blockers[:5],
+    }
+
+    # Also surface the current stage if any stages block exists.
+    if stages:
+        latest_gate = sorted(stages.keys())[-1]
+        stage = stages[latest_gate]
+        summary["current_stage"] = {
+            "target": latest_gate,
+            "score": stage.get("score", 0),
+            "passing": stage.get("score", 0) >= threshold,
+        }
+
+    return summary

--- a/scripts/_readiness/epic.py
+++ b/scripts/_readiness/epic.py
@@ -1,0 +1,601 @@
+"""EPIC readiness scorer — composes SoT scores with EPIC-level dimensions.
+
+Answers "can we build this EPIC?" via nine dimensions. Emits `caused_by`
+pointers on caps and unmet criteria so consumers can traverse the graph
+from EPIC → blocking SoT file without re-querying.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from . import SCHEMA_VERSION, VERSION
+from .common import (
+    HEADING_DEF_RE,
+    ID_RE,
+    SEVERITY_PENALTY,
+    MAX_PENALTY,
+    SoTEntry,
+    build_summary,
+    expand_ranges,
+    extract_section,
+    find_repo_root,
+    index_all_entries,
+    load_domain_profile,
+    load_readiness_config,
+    parse_frontmatter,
+)
+
+
+EPIC_WEIGHTS = {
+    "spec_resolution":        0.20,
+    "spec_depth":             0.15,
+    "test_coverage_declared": 0.15,
+    "upstream_gate":          0.10,
+    "dependency_readiness":   0.10,
+    "ambiguity_load":         0.05,
+    "confidence_avg":         0.15,
+    "status_maturity":        0.05,
+    "file_readiness":         0.05,
+}
+
+# Critical caps: (rule_name, cap_value, reason). Evaluated top-to-bottom; lowest cap wins.
+CRITICAL_CAPS = [
+    ("test_coverage_zero", 55,
+     "test_coverage_declared is 0 — v0.7 requires TEST- entries before build."),
+    ("spec_resolution_low", 60,
+     "spec_resolution below 80% — too many referenced IDs don't resolve."),
+    ("stub_sot_file", 60,
+     "A SoT file referenced by this EPIC is a placeholder stub."),
+]
+
+
+@dataclass
+class EpicContext:
+    """Parsed inputs for a single EPIC's readiness computation."""
+    id: str
+    file: Path
+    inputs: dict
+    referenced_ids: list[str] = field(default_factory=list)
+    unresolved_assumptions: int = 0
+    state: str = "Unknown"
+
+
+# ---------- Parse ---------- #
+
+def parse_epic(epic_file: Path, inputs_override: Optional[dict]) -> EpicContext:
+    text = epic_file.read_text(errors="replace")
+    frontmatter, body = parse_frontmatter(text)
+    inputs = inputs_override or frontmatter.get("readiness_inputs") or {}
+
+    epic_id_match = re.search(r"EPIC-\d{2,3}", epic_file.name)
+    epic_id = inputs.get("target") or (epic_id_match.group(0) if epic_id_match else epic_file.stem)
+
+    ctx = EpicContext(id=epic_id, file=epic_file, inputs=inputs)
+
+    # State line: "> **State**: `Planned`" etc.
+    state_m = re.search(r"\*\*State\*\*[:\s]+`?([A-Za-z ]+?)`?[\s`]*$", body, re.MULTILINE)
+    if state_m:
+        ctx.state = state_m.group(1).strip()
+
+    # Section 3: Context & IDs — extract all referenced IDs (incl. ranges)
+    section_3 = extract_section(body, r"^##\s+.*Context.*IDs.*$")
+    if section_3 is None:
+        section_3 = extract_section(body, r"^##\s+3\.\s+Context")
+    ids_set: set[str] = set()
+    if section_3:
+        for m in ID_RE.finditer(section_3):
+            ids_set.add(f"{m.group(1)}-{m.group(2)}")
+        ids_set |= expand_ranges(section_3)
+    ctx.referenced_ids = sorted(ids_set)
+
+    # Section 1: Assumptions & Ambiguities — count unresolved rows
+    session = extract_section(body, r"^##\s+.*Session State.*$")
+    if session:
+        unresolved = 0
+        for line in session.splitlines():
+            if not line.strip().startswith("|"):
+                continue
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            if len(cells) < 6:
+                continue
+            type_cell = cells[2].upper() if len(cells) > 2 else ""
+            resolution_cell = cells[5].lower() if len(cells) > 5 else ""
+            if type_cell in {"ASSUMPTION", "AMBIGUITY"}:
+                if resolution_cell in {"", "-", "—", "pending"}:
+                    unresolved += 1
+        ctx.unresolved_assumptions = unresolved
+
+    return ctx
+
+
+# ---------- Dimension computations ---------- #
+
+def compute_spec_resolution(ctx: EpicContext, index: dict[str, SoTEntry],
+                            domain: dict, sot_scores: dict) -> tuple[float, list[dict]]:
+    if not ctx.referenced_ids:
+        return 100.0, []
+    resolved = [i for i in ctx.referenced_ids if i in index]
+    unresolved = [i for i in ctx.referenced_ids if i not in index]
+    score = (len(resolved) / len(ctx.referenced_ids)) * 100.0
+    unmet: list[dict] = []
+    for i in unresolved:
+        prefix = i.split("-")[0]
+        owning_file = (domain.get(prefix) or {}).get("file")
+        entry = {"dimension": "spec_resolution", "ref": i,
+                 "reason": f"{i} referenced in EPIC Section 3 but not defined in any SoT/PRD file.",
+                 "severity": "high",
+                 "fix": f"Define {i} in its SoT file, or remove the reference from Section 3."}
+        if owning_file:
+            entry["caused_by"] = owning_file
+            entry["caused_by_score"] = sot_scores.get(owning_file, {}).get("score")
+        unmet.append(entry)
+    return score, unmet
+
+
+def compute_spec_depth(ctx: EpicContext, index: dict[str, SoTEntry]) -> tuple[float, list[dict]]:
+    resolved = [index[i] for i in ctx.referenced_ids if i in index]
+    if not resolved:
+        return 100.0, []
+    stubs = [e for e in resolved if not e.is_non_stub()]
+    non_stub = len(resolved) - len(stubs)
+    score = (non_stub / len(resolved)) * 100.0
+    unmet = [
+        {"dimension": "spec_depth", "ref": e.id,
+         "reason": f"{e.id} in {e.file} has only {e.word_count()} words — likely a stub.",
+         "severity": "medium",
+         "fix": f"Expand {e.id} with rationale, schema, or required sub-sections."}
+        for e in stubs
+    ]
+    return score, unmet
+
+
+def compute_test_coverage(ctx: EpicContext, index: dict[str, SoTEntry],
+                          repo: Path, sot_scores: dict) -> tuple[float, list[dict]]:
+    needs_tests = [i for i in ctx.referenced_ids if i.split("-")[0] in {"API", "BR"}]
+    if not needs_tests:
+        return 100.0, []
+
+    testing_path = "SoT/SoT.TESTING.md"
+    testing_score = sot_scores.get(testing_path, {}).get("score")
+    test_files = list((repo / "SoT").glob("SoT.TESTING.md")) if (repo / "SoT").is_dir() else []
+    if not test_files:
+        return 0.0, [{"dimension": "test_coverage_declared",
+                      "reason": "SoT.TESTING.md not found; no test coverage possible.",
+                      "severity": "high",
+                      "caused_by": testing_path,
+                      "caused_by_score": testing_score,
+                      "fix": "Create SoT.TESTING.md and populate TEST- entries."}]
+
+    test_entries = [e for e in index.values() if e.prefix == "TEST"]
+    if not test_entries:
+        return 0.0, [{"dimension": "test_coverage_declared",
+                      "reason": f"SoT.TESTING.md contains no TEST- entries; {len(needs_tests)} API-/BR- in scope need coverage.",
+                      "severity": "high",
+                      "caused_by": testing_path,
+                      "caused_by_score": testing_score,
+                      "fix": "Populate TEST- entries (Given-When-Then) for each API-/BR- in Section 3."}]
+
+    covered = set()
+    for test_entry in test_entries:
+        for m in ID_RE.finditer(test_entry.body):
+            ref = f"{m.group(1)}-{m.group(2)}"
+            if ref in needs_tests:
+                covered.add(ref)
+    score = (len(covered) / len(needs_tests)) * 100.0
+    missing = [i for i in needs_tests if i not in covered]
+    unmet = [
+        {"dimension": "test_coverage_declared", "ref": i,
+         "reason": f"{i} has no TEST- entry referencing it.",
+         "severity": "high",
+         "fix": f"Add a TEST- entry in SoT.TESTING.md that implements/verifies {i}."}
+        for i in missing
+    ] if missing else []
+    return score, unmet
+
+
+def compute_upstream_gate(ctx: EpicContext, readiness_json: Optional[dict]) -> tuple[float, list[dict]]:
+    if not readiness_json or "stage" not in readiness_json:
+        return 100.0, []
+    stage_score = readiness_json["stage"].get("score", 0)
+    threshold = ctx.inputs.get("threshold_warn", 70)
+    if stage_score >= threshold:
+        return 100.0, []
+    return (stage_score / threshold) * 100.0, [{
+        "dimension": "upstream_gate",
+        "reason": f"Owning stage readiness score ({stage_score}) below EPIC threshold ({threshold}).",
+        "severity": "medium",
+        "fix": "Raise stage readiness before building this EPIC, or lower threshold.",
+    }]
+
+
+def compute_dependency_readiness(ctx: EpicContext, repo: Path) -> tuple[float, list[dict]]:
+    deps = ctx.inputs.get("depends_on_epics") or []
+    if not deps:
+        return 100.0, []
+    complete = 0
+    unmet_items: list[dict] = []
+    for dep in deps:
+        dep_files = list((repo / "epics").glob(f"{dep}*.md"))
+        if not dep_files:
+            unmet_items.append({"dimension": "dependency_readiness", "ref": dep,
+                                "reason": f"Dependency {dep} not found in epics/.",
+                                "severity": "high", "fix": f"Create {dep} or remove the dependency."})
+            continue
+        text = dep_files[0].read_text(errors="replace")
+        state_m = re.search(r"\*\*State\*\*[:\s]+`?([A-Za-z ]+?)`?[\s`]*$", text, re.MULTILINE)
+        state = state_m.group(1).strip() if state_m else "Unknown"
+        if state == "Complete":
+            complete += 1
+        else:
+            unmet_items.append({"dimension": "dependency_readiness", "ref": dep,
+                                "reason": f"Dependency {dep} state is '{state}', needs 'Complete'.",
+                                "severity": "high",
+                                "fix": f"Complete {dep} before starting this EPIC."})
+    score = (complete / len(deps)) * 100.0
+    return score, unmet_items
+
+
+def compute_ambiguity_load(ctx: EpicContext) -> tuple[float, list[dict]]:
+    score = max(0.0, 100.0 - ctx.unresolved_assumptions * 20.0)
+    unmet = []
+    if ctx.unresolved_assumptions > 0:
+        unmet.append({
+            "dimension": "ambiguity_load",
+            "reason": f"{ctx.unresolved_assumptions} unresolved row(s) in Assumptions & Ambiguities log.",
+            "severity": "medium",
+            "fix": "Resolve or defer the items in Session State → Assumptions & Ambiguities.",
+        })
+    return score, unmet
+
+
+def compute_confidence_avg(ctx: EpicContext, index: dict[str, SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    resolved = [index[i] for i in ctx.referenced_ids if i in index]
+    vals = [e.confidence() for e in resolved if e.confidence() is not None]
+    if not vals:
+        return None, []
+    avg = sum(vals) / len(vals)
+    score = (avg / 5.0) * 100.0
+    floor = ctx.inputs.get("confidence_floor", 3)
+    low = [e for e in resolved if e.confidence() is not None and e.confidence() < floor]
+    unmet = [
+        {"dimension": "confidence_avg", "ref": e.id,
+         "reason": f"{e.id} confidence {e.confidence()}/5 below floor {floor}/5.",
+         "severity": "low",
+         "fix": f"Gather stronger evidence for {e.id} or adjust confidence_floor."}
+        for e in low
+    ]
+    return score, unmet
+
+
+def compute_status_maturity(ctx: EpicContext, index: dict[str, SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    resolved = [index[i] for i in ctx.referenced_ids if i in index]
+    with_status = [(e, e.status()) for e in resolved if e.status() is not None]
+    if not with_status:
+        return None, []
+    non_draft = [e for e, s in with_status if s.lower() != "draft"]
+    score = (len(non_draft) / len(with_status)) * 100.0
+    drafts = [e for e, s in with_status if s.lower() == "draft"]
+    unmet = [
+        {"dimension": "status_maturity", "ref": e.id,
+         "reason": f"{e.id} Status is still 'Draft'.",
+         "severity": "low",
+         "fix": f"Promote {e.id} to Active once validated."}
+        for e in drafts
+    ]
+    return score, unmet
+
+
+def compute_file_readiness(ctx: EpicContext, index: dict[str, SoTEntry],
+                           repo: Path, domain: dict, sot_scores: dict) -> tuple[float, list[dict]]:
+    """Are the SoT files referenced by Section 3 populated (not placeholder stubs)?
+
+    Includes files that *would* own dangling refs via domain profile prefix
+    mapping — otherwise a repo where UJ-001..006 reference a placeholder
+    USER_JOURNEYS.md would escape detection because the IDs never resolved.
+    """
+    files_used: set[str] = set()
+    for i in ctx.referenced_ids:
+        if i in index:
+            files_used.add(index[i].file)
+        else:
+            prefix = i.split("-")[0]
+            info = domain.get(prefix) if domain else None
+            if info and info.get("file"):
+                owning = info["file"]
+                if (repo / owning).is_file():
+                    files_used.add(owning)
+    if not files_used:
+        return 100.0, []
+
+    stubs: list[str] = []
+    for rel in files_used:
+        p = repo / rel
+        if not p.is_file():
+            stubs.append(rel)
+            continue
+        text = p.read_text(errors="replace")
+        headings = [l for l in text.splitlines() if HEADING_DEF_RE.match(l)]
+        body_lower = text.lower()
+        placeholder_markers = ("pending prd development", "todo", "placeholder", "to be filled")
+        has_placeholder = any(m in body_lower for m in placeholder_markers)
+        if not headings and (has_placeholder or len(text.strip()) < 100):
+            stubs.append(rel)
+
+    if not stubs:
+        return 100.0, []
+    score = ((len(files_used) - len(stubs)) / len(files_used)) * 100.0
+    unmet = [
+        {"dimension": "file_readiness", "ref": s,
+         "reason": f"{s} is a stub/placeholder file with no real entries.",
+         "severity": "high",
+         "caused_by": s,
+         "caused_by_score": sot_scores.get(s, {}).get("score"),
+         "fix": f"Populate {s} with real SoT entries before this EPIC begins."}
+        for s in stubs
+    ]
+    return score, unmet
+
+
+# ---------- Aggregation ---------- #
+
+def apply_overrides(ctx: EpicContext, readiness_config: dict) -> dict:
+    state = {d: "enabled" for d in EPIC_WEIGHTS}
+    repo_defaults = readiness_config.get("dimension_defaults") or {}
+    for k, v in repo_defaults.items():
+        if k in state:
+            state[k] = v
+    epic_overrides = ctx.inputs.get("dimension_overrides") or {}
+    for k, v in epic_overrides.items():
+        if k in state:
+            state[k] = v
+    return state
+
+
+def renormalize_weights(override_state: dict[str, str],
+                        scores: dict[str, Optional[float]]) -> dict[str, float]:
+    active = {
+        d: EPIC_WEIGHTS[d] for d in EPIC_WEIGHTS
+        if override_state.get(d) != "disabled" and scores.get(d) is not None
+    }
+    total = sum(active.values())
+    return {d: w / total for d, w in active.items()} if total else {}
+
+
+def compute(epic_file: Path, repo: Path, inputs_override: Optional[dict]) -> dict:
+    domain = load_domain_profile(repo)
+    config = load_readiness_config(repo)
+    index = index_all_entries(repo)
+    ctx = parse_epic(epic_file, inputs_override)
+
+    existing: Optional[dict] = None
+    readiness_path = repo / "status" / "readiness.json"
+    if readiness_path.is_file():
+        try:
+            existing = json.loads(readiness_path.read_text())
+        except json.JSONDecodeError:
+            existing = None
+    sot_scores = (existing or {}).get("sot_files", {}) if existing else {}
+
+    dims: dict[str, dict] = {}
+    unmet: list[dict] = []
+
+    s, u = compute_spec_resolution(ctx, index, domain, sot_scores)
+    dims["spec_resolution"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_spec_depth(ctx, index)
+    dims["spec_depth"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_test_coverage(ctx, index, repo, sot_scores)
+    dims["test_coverage_declared"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_upstream_gate(ctx, existing)
+    dims["upstream_gate"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_dependency_readiness(ctx, repo)
+    dims["dependency_readiness"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_ambiguity_load(ctx)
+    dims["ambiguity_load"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    conf_score, u = compute_confidence_avg(ctx, index)
+    dims["confidence_avg"] = {"score": conf_score if conf_score is not None else None}
+    unmet.extend(u)
+
+    stat_score, u = compute_status_maturity(ctx, index)
+    dims["status_maturity"] = {"score": stat_score if stat_score is not None else None}
+    unmet.extend(u)
+
+    s, u = compute_file_readiness(ctx, index, repo, domain, sot_scores)
+    dims["file_readiness"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    override_state = apply_overrides(ctx, config)
+    score_map = {d: dims[d].get("score") for d in dims}
+    weights = renormalize_weights(override_state, score_map)
+
+    weighted_score = 0.0
+    for d, w in weights.items():
+        dims[d]["weight"] = round(w, 3)
+        weighted_score += (score_map[d] or 0) * w
+
+    for d in dims:
+        if d not in weights:
+            if override_state.get(d) == "disabled":
+                dims[d]["status"] = "disabled"
+            elif score_map[d] is None:
+                dims[d]["status"] = "not_applicable"
+            dims[d].pop("score", None)
+
+    raw_penalty = sum(SEVERITY_PENALTY.get(c.get("severity", "medium"), 3) for c in unmet)
+    penalty = min(raw_penalty, MAX_PENALTY)
+
+    # Critical caps with caused_by enrichment
+    caps_applied: list[dict] = []
+    cap_score = 100
+    if score_map.get("test_coverage_declared") == 0 and ctx.referenced_ids:
+        needs_tests = any(i.split("-")[0] in {"API", "BR"} for i in ctx.referenced_ids)
+        if needs_tests:
+            cap_score = min(cap_score, CRITICAL_CAPS[0][1])
+            caps_applied.append({"rule": "test_coverage_zero", "cap": CRITICAL_CAPS[0][1],
+                                 "reason": CRITICAL_CAPS[0][2],
+                                 "caused_by": "SoT/SoT.TESTING.md",
+                                 "caused_by_score": sot_scores.get("SoT/SoT.TESTING.md", {}).get("score")})
+    if score_map.get("spec_resolution", 100) < 80:
+        cap_score = min(cap_score, CRITICAL_CAPS[1][1])
+        dangling_files: dict[str, int] = {}
+        for c in unmet:
+            if c.get("dimension") == "spec_resolution" and c.get("caused_by"):
+                dangling_files[c["caused_by"]] = dangling_files.get(c["caused_by"], 0) + 1
+        worst = max(dangling_files.items(), key=lambda x: x[1]) if dangling_files else (None, 0)
+        caps_applied.append({"rule": "spec_resolution_low", "cap": CRITICAL_CAPS[1][1],
+                             "reason": CRITICAL_CAPS[1][2],
+                             "caused_by": worst[0],
+                             "caused_by_score": sot_scores.get(worst[0], {}).get("score") if worst[0] else None})
+    if score_map.get("file_readiness", 100) < 100:
+        cap_score = min(cap_score, CRITICAL_CAPS[2][1])
+        stub_files = [c.get("caused_by") for c in unmet
+                      if c.get("dimension") == "file_readiness" and c.get("caused_by")]
+        caps_applied.append({"rule": "stub_sot_file", "cap": CRITICAL_CAPS[2][1],
+                             "reason": CRITICAL_CAPS[2][2],
+                             "caused_by": stub_files[0] if stub_files else None,
+                             "caused_by_score": sot_scores.get(stub_files[0], {}).get("score") if stub_files else None})
+
+    penalized = max(0.0, weighted_score - penalty)
+    final_score = min(cap_score, penalized)
+
+    thresholds = {
+        "warn": ctx.inputs.get("threshold_warn", 70),
+        "block": ctx.inputs.get("threshold_block", 50),
+    }
+
+    return {
+        "target": ctx.id,
+        "work_type": "epic",
+        "state": ctx.state,
+        "score": round(final_score, 1),
+        "weighted_score": round(weighted_score, 1),
+        "penalty": penalty,
+        "cap_applied": cap_score if caps_applied else None,
+        "caps": caps_applied,
+        "threshold_warn": thresholds["warn"],
+        "threshold_block": thresholds["block"],
+        "dimensions": dims,
+        "unmet_criteria": unmet,
+        "referenced_ids_count": len(ctx.referenced_ids),
+        "file": str(epic_file.relative_to(repo)),
+    }
+
+
+# ---------- CLI ---------- #
+
+def main_cli() -> int:
+    p = argparse.ArgumentParser(description="Compute PRD-CE EPIC readiness score.")
+    p.add_argument("epic_file", type=Path)
+    p.add_argument("--repo", type=Path, default=None)
+    p.add_argument("--inputs", type=Path, default=None)
+    p.add_argument("--output", type=str, default=None)
+    p.add_argument("--merge", action="store_true")
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    if not args.epic_file.is_file():
+        print(f"error: epic file not found: {args.epic_file}", file=sys.stderr)
+        return 2
+
+    args.epic_file = args.epic_file.resolve()
+    repo = args.repo.resolve() if args.repo else find_repo_root(args.epic_file)
+    inputs_override = None
+    if args.inputs:
+        if not args.inputs.is_file():
+            print(f"error: inputs file not found: {args.inputs}", file=sys.stderr)
+            return 2
+        with args.inputs.open() as f:
+            loaded = yaml.safe_load(f) or {}
+        inputs_override = loaded.get("readiness_inputs", loaded)
+
+    epic_block = compute(args.epic_file, repo, inputs_override)
+
+    existing_full: dict = {}
+    readiness_file = repo / "status" / "readiness.json"
+    if readiness_file.is_file():
+        try:
+            existing_full = json.loads(readiness_file.read_text())
+        except json.JSONDecodeError:
+            existing_full = {}
+
+    output = {
+        "last_computed": datetime.now(timezone.utc).isoformat(),
+        "computed_by": f"compute-readiness@{VERSION}",
+        "schema_version": SCHEMA_VERSION,
+        "sot_files": existing_full.get("sot_files", {}),
+        "epics": {epic_block["target"]: epic_block},
+        "stages": existing_full.get("stages", {}),
+    }
+
+    if args.merge and existing_full.get("epics"):
+        output["epics"] = {**existing_full["epics"], epic_block["target"]: epic_block}
+
+    # Back-propagate implicit consumers: SoT files cited as caused_by here
+    # are consumers even if not referenced explicitly in Section 3.
+    implicit_consumers: set[str] = set()
+    for cap in epic_block.get("caps", []):
+        if cap.get("caused_by"):
+            implicit_consumers.add(cap["caused_by"])
+    for c in epic_block.get("unmet_criteria", []):
+        if c.get("caused_by"):
+            implicit_consumers.add(c["caused_by"])
+    for sot_path in implicit_consumers:
+        if sot_path in output["sot_files"]:
+            current = output["sot_files"][sot_path].get("consumed_by_epics", [])
+            if epic_block["target"] not in current:
+                current.append(epic_block["target"])
+                current.sort()
+                output["sot_files"][sot_path]["consumed_by_epics"] = current
+
+    output["summary"] = build_summary(output)
+
+    out_json = json.dumps(output, indent=2, ensure_ascii=False)
+    if args.output == "-":
+        print(out_json)
+    else:
+        out_path = Path(args.output) if args.output else readiness_file
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(out_json + "\n")
+        if args.verbose:
+            print(f"wrote {out_path}")
+
+    if args.verbose:
+        print(f"\n{epic_block['target']} score: {epic_block['score']} "
+              f"(warn<{epic_block['threshold_warn']}, block<{epic_block['threshold_block']})")
+        for d, info in epic_block["dimensions"].items():
+            marker = f"  {d:<24}"
+            if "status" in info:
+                print(f"{marker} [{info['status']}]")
+            else:
+                w = info.get("weight", 0)
+                print(f"{marker} score={info['score']:>5}  weight={w:.3f}")
+        if epic_block["unmet_criteria"]:
+            print(f"\n{len(epic_block['unmet_criteria'])} unmet criteria:")
+            for c in epic_block["unmet_criteria"][:10]:
+                print(f"  - [{c['severity']}] {c.get('ref', c['dimension'])}: {c['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/_readiness/sot.py
+++ b/scripts/_readiness/sot.py
@@ -1,0 +1,374 @@
+"""SoT file readiness scorer — the primitive layer.
+
+Answers "is SoT/<file>.md in good shape?" via six dimensions:
+entry_count, entry_depth, cross_ref_density, orphan_rate, status_coverage,
+confidence_coverage. status/confidence auto-disable when the repo hasn't
+adopted those conventions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from . import SCHEMA_VERSION, VERSION
+from .common import (
+    HEADING_DEF_RE,
+    ID_RE,
+    PLACEHOLDER_MARKERS,
+    SEVERITY_PENALTY,
+    MAX_PENALTY,
+    SoTEntry,
+    build_summary,
+    collect_all_references,
+    find_repo_root,
+    index_all_entries,
+    load_domain_profile,
+)
+
+
+SOT_WEIGHTS = {
+    "entry_count":         0.15,
+    "entry_depth":         0.25,
+    "cross_ref_density":   0.20,
+    "orphan_rate":         0.15,
+    "status_coverage":     0.10,
+    "confidence_coverage": 0.15,
+}
+
+CRITICAL_CAPS = {
+    "placeholder_file": 10,   # no entries + placeholder marker
+    "nearly_empty":     40,   # <3 entries but referenced externally
+}
+
+
+# ---------- Dimension computations ---------- #
+
+def is_placeholder_file(text: str, entries: list[SoTEntry]) -> bool:
+    if entries:
+        return False
+    lower = text.lower()
+    return any(m in lower for m in PLACEHOLDER_MARKERS) or len(text.strip()) < 100
+
+
+def compute_entry_count(entries: list[SoTEntry], text: str) -> tuple[float, list[dict], bool]:
+    """Populated-enough score + placeholder-file flag."""
+    is_placeholder = is_placeholder_file(text, entries)
+    if is_placeholder:
+        return 0.0, [{
+            "dimension": "entry_count",
+            "reason": "File is a placeholder stub with no ID entries.",
+            "severity": "high",
+            "fix": "Populate with real entries or remove references that need this file.",
+        }], True
+    n = len(entries)
+    if n == 0:
+        return 0.0, [{
+            "dimension": "entry_count",
+            "reason": "File has no ID entries.",
+            "severity": "high",
+            "fix": "Add at least one ID entry to establish the file.",
+        }], False
+    if n < 3:
+        return 50.0, [{
+            "dimension": "entry_count",
+            "reason": f"Only {n} entries — file is sparse.",
+            "severity": "medium",
+            "fix": "Add entries to reach meaningful coverage for the domain.",
+        }], False
+    return 100.0, [], False
+
+
+def compute_entry_depth(entries: list[SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    if not entries:
+        return None, []
+    stubs = [e for e in entries if not e.is_non_stub()]
+    score = ((len(entries) - len(stubs)) / len(entries)) * 100.0
+    unmet = [
+        {"dimension": "entry_depth", "ref": e.id,
+         "reason": f"{e.id} is only {e.word_count()} words — likely a stub.",
+         "severity": "medium",
+         "fix": f"Expand {e.id} with rationale, schema, or required sub-sections."}
+        for e in stubs
+    ]
+    return score, unmet
+
+
+def compute_cross_ref_density(entries: list[SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    if not entries:
+        return None, []
+    with_refs = [e for e in entries if e.outbound_refs()]
+    score = (len(with_refs) / len(entries)) * 100.0
+    isolated = [e for e in entries if not e.outbound_refs()]
+    unmet = [
+        {"dimension": "cross_ref_density", "ref": e.id,
+         "reason": f"{e.id} references no other IDs — isolated in the knowledge graph.",
+         "severity": "low",
+         "fix": f"Link {e.id} to related BR-/API-/UJ- entries."}
+        for e in isolated[:5]
+    ]
+    return score, unmet
+
+
+def compute_orphan_rate(entries: list[SoTEntry], own_file: str,
+                        all_refs: dict[str, set[str]]) -> tuple[Optional[float], list[dict]]:
+    if not entries:
+        return None, []
+    orphans = [e for e in entries if not (all_refs.get(e.id, set()) - {own_file})]
+    cited = len(entries) - len(orphans)
+    score = (cited / len(entries)) * 100.0
+    unmet = [
+        {"dimension": "orphan_rate", "ref": e.id,
+         "reason": f"{e.id} is never referenced outside {own_file} — orphaned.",
+         "severity": "low",
+         "fix": f"Ensure {e.id} is cited from EPICs, PRD, or related SoT entries — "
+                f"or remove if unused."}
+        for e in orphans[:5]
+    ]
+    return score, unmet
+
+
+def compute_status_coverage(entries: list[SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    if not entries:
+        return None, []
+    with_status = [e for e in entries if e.has_status()]
+    if not with_status:
+        return None, []  # repo doesn't use Status convention
+    score = (len(with_status) / len(entries)) * 100.0
+    missing = [e for e in entries if not e.has_status()]
+    unmet = [
+        {"dimension": "status_coverage", "ref": e.id,
+         "reason": f"{e.id} has no Status: field.",
+         "severity": "low",
+         "fix": f"Add 'Status: Active|Draft|Deprecated' to {e.id}."}
+        for e in missing[:5]
+    ]
+    return score, unmet
+
+
+def compute_confidence_coverage(entries: list[SoTEntry]) -> tuple[Optional[float], list[dict]]:
+    if not entries:
+        return None, []
+    with_conf = [e for e in entries if e.has_confidence()]
+    if not with_conf:
+        return None, []
+    score = (len(with_conf) / len(entries)) * 100.0
+    missing = [e for e in entries if not e.has_confidence()]
+    unmet = [
+        {"dimension": "confidence_coverage", "ref": e.id,
+         "reason": f"{e.id} has no Confidence: N/5 field.",
+         "severity": "low",
+         "fix": f"Add 'Confidence: N/5 (source: ...)' to {e.id} per ghm-id-register."}
+        for e in missing[:5]
+    ]
+    return score, unmet
+
+
+# ---------- Consumer map (SoT → EPICs that reference it) ---------- #
+
+def build_epic_consumer_map(repo: Path, domain: dict) -> dict[str, list[str]]:
+    """Return `{sot_file_rel_path: [epic_id, ...]}` — which EPICs consume each file.
+
+    An EPIC consumes a SoT file if its Section 3 references any ID whose owning
+    prefix maps to that file via the domain profile.
+    """
+    epics_dir = repo / "epics"
+    if not epics_dir.is_dir():
+        return {}
+    consumers: dict[str, set[str]] = {}
+    for epic in epics_dir.glob("EPIC-*.md"):
+        if epic.name == "EPIC_TEMPLATE.md":
+            continue
+        text = epic.read_text(errors="replace")
+        matches = list(re.finditer(r"^##\s+.*Context.*IDs.*$", text, re.MULTILINE))
+        if not matches:
+            continue
+        start = matches[0].end()
+        next_heading = re.search(r"^#{1,2}\s+", text[start:], re.MULTILINE)
+        section_3 = text[start:start + next_heading.start()] if next_heading else text[start:]
+        epic_id_m = re.search(r"EPIC-\d{2,3}", epic.name)
+        if not epic_id_m:
+            continue
+        epic_id = epic_id_m.group(0)
+        prefixes_used = {m.group(1) for m in ID_RE.finditer(section_3)}
+        for prefix in prefixes_used:
+            info = domain.get(prefix)
+            if info and info.get("file"):
+                consumers.setdefault(info["file"], set()).add(epic_id)
+    return {f: sorted(ids) for f, ids in consumers.items()}
+
+
+# ---------- Aggregation ---------- #
+
+def renormalize(scores: dict[str, Optional[float]]) -> dict[str, float]:
+    active = {d: SOT_WEIGHTS[d] for d in SOT_WEIGHTS if scores.get(d) is not None}
+    total = sum(active.values())
+    return {d: w / total for d, w in active.items()} if total else {}
+
+
+def compute_file(sot_file: Path, repo: Path, index: dict[str, SoTEntry],
+                 all_refs: dict[str, set[str]],
+                 consumer_map: dict[str, list[str]]) -> dict:
+    rel = str(sot_file.relative_to(repo))
+    text = sot_file.read_text(errors="replace")
+    entries = [e for e in index.values() if e.file == rel]
+
+    dims: dict[str, dict] = {}
+    unmet: list[dict] = []
+
+    s, u, is_placeholder = compute_entry_count(entries, text)
+    dims["entry_count"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_entry_depth(entries)
+    dims["entry_depth"] = {"score": round(s, 1) if s is not None else None}
+    unmet.extend(u)
+
+    s, u = compute_cross_ref_density(entries)
+    dims["cross_ref_density"] = {"score": round(s, 1) if s is not None else None}
+    unmet.extend(u)
+
+    s, u = compute_orphan_rate(entries, rel, all_refs)
+    dims["orphan_rate"] = {"score": round(s, 1) if s is not None else None}
+    unmet.extend(u)
+
+    s, u = compute_status_coverage(entries)
+    dims["status_coverage"] = {"score": s if s is not None else None}
+    unmet.extend(u)
+
+    s, u = compute_confidence_coverage(entries)
+    dims["confidence_coverage"] = {"score": s if s is not None else None}
+    unmet.extend(u)
+
+    score_map = {d: dims[d].get("score") for d in dims}
+    weights = renormalize(score_map)
+
+    weighted = 0.0
+    for d, w in weights.items():
+        dims[d]["weight"] = round(w, 3)
+        weighted += (score_map[d] or 0) * w
+
+    for d in dims:
+        if d not in weights:
+            dims[d]["status"] = "not_applicable"
+            dims[d].pop("score", None)
+
+    raw_penalty = sum(SEVERITY_PENALTY.get(c.get("severity", "medium"), 3) for c in unmet)
+    penalty = min(raw_penalty, MAX_PENALTY)
+
+    cap = 100
+    caps_applied: list[dict] = []
+    if is_placeholder:
+        cap = min(cap, CRITICAL_CAPS["placeholder_file"])
+        caps_applied.append({"rule": "placeholder_file", "cap": CRITICAL_CAPS["placeholder_file"],
+                             "reason": "File is placeholder with no real entries."})
+    elif 0 < len(entries) < 3 and any(all_refs.get(e.id, set()) - {rel} for e in entries):
+        cap = min(cap, CRITICAL_CAPS["nearly_empty"])
+        caps_applied.append({"rule": "nearly_empty", "cap": CRITICAL_CAPS["nearly_empty"],
+                             "reason": f"Only {len(entries)} entries but file is referenced externally."})
+
+    final = min(cap, max(0.0, weighted - penalty))
+
+    return {
+        "target": rel,
+        "work_type": "sot",
+        "score": round(final, 1),
+        "weighted_score": round(weighted, 1),
+        "penalty": penalty,
+        "cap_applied": cap if caps_applied else None,
+        "caps": caps_applied,
+        "entry_count": len(entries),
+        "consumed_by_epics": consumer_map.get(rel, []),
+        "dimensions": dims,
+        "unmet_criteria": unmet,
+    }
+
+
+# ---------- CLI ---------- #
+
+def discover_sot_files(repo: Path) -> list[Path]:
+    sot_dir = repo / "SoT"
+    if not sot_dir.is_dir():
+        return []
+    return sorted(p for p in sot_dir.glob("*.md")
+                  if p.name not in {"SoT.README.md", "SoT.UNIQUE_ID_SYSTEM.md"})
+
+
+def main_cli() -> int:
+    p = argparse.ArgumentParser(description="Compute SoT file readiness scores.")
+    p.add_argument("target", type=str, help='SoT file path, or "all".')
+    p.add_argument("--repo", type=Path, default=None)
+    p.add_argument("--output", type=str, default=None)
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    if args.target == "all":
+        repo = args.repo.resolve() if args.repo else find_repo_root(Path.cwd())
+        targets = discover_sot_files(repo)
+        if not targets:
+            print(f"error: no SoT files found under {repo}/SoT/", file=sys.stderr)
+            return 2
+    else:
+        target = Path(args.target).resolve()
+        if not target.is_file():
+            print(f"error: SoT file not found: {target}", file=sys.stderr)
+            return 2
+        repo = args.repo.resolve() if args.repo else find_repo_root(target)
+        targets = [target]
+
+    domain = load_domain_profile(repo)
+    index = index_all_entries(repo)
+    all_refs = collect_all_references(repo)
+    consumer_map = build_epic_consumer_map(repo, domain)
+
+    sot_blocks: dict[str, dict] = {}
+    for sot in targets:
+        block = compute_file(sot, repo, index, all_refs, consumer_map)
+        sot_blocks[block["target"]] = block
+
+    out_path = (Path(args.output) if args.output and args.output != "-"
+                else (repo / "status" / "readiness.json"))
+    existing: dict = {}
+    if args.output != "-" and out_path.is_file():
+        try:
+            existing = json.loads(out_path.read_text())
+        except json.JSONDecodeError:
+            existing = {}
+
+    output = {
+        "last_computed": datetime.now(timezone.utc).isoformat(),
+        "computed_by": f"compute-sot-readiness@{VERSION}",
+        "schema_version": SCHEMA_VERSION,
+        "sot_files": sot_blocks,
+        "epics": existing.get("epics", {}),
+        "stages": existing.get("stages", {}),
+    }
+    output["summary"] = build_summary(output)
+
+    out_json = json.dumps(output, indent=2, ensure_ascii=False)
+    if args.output == "-":
+        print(out_json)
+    else:
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(out_json + "\n")
+        if args.verbose:
+            print(f"wrote {out_path}")
+
+    if args.verbose:
+        print()
+        print(f"{'File':<40} {'score':>6}  {'weighted':>8}  {'entries':>7}  {'unmet':>5}")
+        print("-" * 80)
+        for path, block in sorted(sot_blocks.items()):
+            name = path.split("/", 1)[-1] if "/" in path else path
+            print(f"{name:<40} {block['score']:>6}  {block['weighted_score']:>8}  "
+                  f"{block['entry_count']:>7}  {len(block['unmet_criteria']):>5}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/_readiness/stage.py
+++ b/scripts/_readiness/stage.py
@@ -1,0 +1,428 @@
+"""PRD stage readiness — thin composer over SoT + EPIC scores.
+
+Answers "can we advance v0.X → v0.Y?" by combining:
+  - mandatory artifact counts from GATE_REQUIREMENTS (mirrors gate-criteria.md)
+  - mean readiness of relevant SoT files (read from existing readiness.json)
+  - cross-reference integrity across the repo
+  - mean EPIC score (v0.7+ gates only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from . import SCHEMA_VERSION, VERSION
+from .common import (
+    HEADING_DEF_RE,
+    ID_RE,
+    SEVERITY_PENALTY,
+    MAX_PENALTY,
+    build_summary,
+    find_repo_root,
+)
+
+
+STAGE_WEIGHTS = {
+    "required_ids_present":      0.30,
+    "relevant_sot_readiness":    0.30,
+    "cross_ref_integrity":       0.20,
+    "downstream_epic_readiness": 0.20,
+}
+
+# Gate transition requirements — mirrors .claude/skills/ghm-gate-check/references/gate-criteria.md.
+# `required_prefixes`: min counts per prefix. `prefix_aliases`: accept any from the list
+# (so DBT can alternately be ENT, etc.). `relevant_sots`: files whose readiness rolls into
+# this gate's score. `enables_downstream_epic_readiness`: true for v0.7+ gates where EPICs exist.
+GATE_REQUIREMENTS: dict[str, dict] = {
+    "v0.2": {
+        "name": "v0.1 → v0.2 (Spark → Market Definition)",
+        "required_prefixes": {"CFD": 3},
+        "relevant_sots": ["SoT/SoT.customer_feedback.md"],
+    },
+    "v0.3": {
+        "name": "v0.2 → v0.3 (Market Definition → Commercial Model)",
+        "required_prefixes": {"CFD": 3, "BR": 1},
+        "relevant_sots": ["SoT/SoT.customer_feedback.md", "SoT/SoT.BUSINESS_RULES.md"],
+    },
+    "v0.4": {
+        "name": "v0.3 → v0.4 (Commercial Model → User Journeys)",
+        "required_prefixes": {"BR": 3, "KPI": 1, "CFD": 5, "FEA": 1},
+        "relevant_sots": ["SoT/SoT.BUSINESS_RULES.md", "SoT/SoT.customer_feedback.md"],
+    },
+    "v0.5": {
+        "name": "v0.4 → v0.5 (User Journeys → Red Team)",
+        "required_prefixes": {"PER": 1, "UJ": 3},
+        "relevant_sots": ["SoT/SoT.USER_JOURNEYS.md", "SoT/SoT.BUSINESS_RULES.md"],
+    },
+    "v0.6": {
+        "name": "v0.5 → v0.6 (Red Team → Architecture)",
+        "required_prefixes": {"RISK": 5, "TECH": 3},
+        "relevant_sots": ["SoT/SoT.RISKS.md", "SoT/SoT.TECHNICAL_DECISIONS.md"],
+    },
+    "v0.7": {
+        "name": "v0.6 → v0.7 (Architecture → Build)",
+        "required_prefixes": {"ARC": 1, "API": 1, "DBT": 1},
+        "prefix_aliases": {"DBT": ["DBT", "ENT"]},
+        "relevant_sots": [
+            "SoT/SoT.TECHNICAL_DECISIONS.md",
+            "SoT/SoT.API_CONTRACTS.md",
+            "SoT/SoT.DATA_MODEL.md",
+        ],
+    },
+    "v0.8": {
+        "name": "v0.7 → v0.8 (Build → Deployment)",
+        "required_prefixes": {"EPIC": 1, "TEST": 1},
+        "relevant_sots": [
+            "SoT/SoT.TESTING.md",
+            "SoT/SoT.API_CONTRACTS.md",
+            "SoT/SoT.DATA_MODEL.md",
+            "SoT/SoT.BUSINESS_RULES.md",
+        ],
+        "enables_downstream_epic_readiness": True,
+    },
+    "v0.9": {
+        "name": "v0.8 → v0.9 (Deployment → GTM)",
+        "required_prefixes": {"DEP": 1, "RUN": 1, "MON": 1},
+        "relevant_sots": ["SoT/SoT.DEPLOYMENT.md"],
+        "enables_downstream_epic_readiness": True,
+    },
+    "v1.0": {
+        "name": "v0.9 → v1.0 (GTM → Launch)",
+        "required_prefixes": {"GTM": 1, "KPI": 3},
+        "relevant_sots": ["SoT/SoT.customer_feedback.md"],
+        "enables_downstream_epic_readiness": True,
+    },
+}
+
+
+# ---------- Autodetect ---------- #
+
+def autodetect_gate(repo: Path) -> Optional[str]:
+    """Read PRD.md's 'Next Target Gate' field; prefer the destination in arrow form."""
+    prd = repo / "PRD.md"
+    if not prd.is_file():
+        return None
+    text = prd.read_text(errors="replace")
+    arrow_m = re.search(r"Next Target Gate.*?v0?\.\d+.*?(?:\u2192|->|to)\s*(v\d\.\d+|v1\.0)", text)
+    if arrow_m:
+        return arrow_m.group(1)
+    m = re.search(r"Next Target Gate.*?(v0?\.\d|v1\.0)", text)
+    if m:
+        return m.group(1)
+    m = re.search(r"Current Lifecycle Gate.*?(v0?\.\d|v1\.0)", text)
+    if m:
+        current = m.group(1)
+        if current == "v1.0":
+            return None
+        major, minor = current.split(".")
+        return f"{major}.{int(minor) + 1}"
+    return None
+
+
+# ---------- ID indexing for stage scope ---------- #
+
+def index_all_ids(repo: Path) -> dict[str, set[str]]:
+    """{prefix: {id, ...}} across SoT/, PRD.md, epics/, README.md.
+
+    Handles EPIC- via filename (`epics/EPIC-NN-*.md`) since EPICs use `#` not `##`.
+    """
+    out: dict[str, set[str]] = {}
+    files: list[Path] = []
+    sot = repo / "SoT"
+    if sot.is_dir():
+        files.extend(sot.glob("*.md"))
+    for extra in ("PRD.md", "README.md"):
+        p = repo / extra
+        if p.is_file():
+            files.append(p)
+    epics = repo / "epics"
+    if epics.is_dir():
+        for p in epics.glob("EPIC-*.md"):
+            m = re.match(r"(EPIC-\d{2,3})", p.name)
+            if m:
+                out.setdefault("EPIC", set()).add(m.group(1))
+            if p.name != "EPIC_TEMPLATE.md":
+                files.append(p)
+
+    for f in files:
+        for line in f.read_text(errors="replace").splitlines():
+            m = HEADING_DEF_RE.match(line)
+            if m:
+                prefix, num = m.group(1).split("-")
+                out.setdefault(prefix, set()).add(f"{prefix}-{num}")
+    return out
+
+
+# ---------- Dimension computations ---------- #
+
+def compute_required_ids_present(gate_cfg: dict, id_index: dict[str, set[str]]) -> tuple[float, list[dict]]:
+    required = gate_cfg.get("required_prefixes", {})
+    aliases = gate_cfg.get("prefix_aliases", {})
+    if not required:
+        return 100.0, []
+    met = 0
+    unmet: list[dict] = []
+    for prefix, min_count in required.items():
+        count = sum(len(id_index.get(alias, set())) for alias in aliases.get(prefix, [prefix]))
+        if count >= min_count:
+            met += 1
+        else:
+            unmet.append({
+                "dimension": "required_ids_present",
+                "ref": prefix,
+                "reason": f"Found {count} {prefix}- entries; gate requires \u2265{min_count}.",
+                "severity": "high",
+                "fix": f"Author {min_count - count} more {prefix}- entries before advancing.",
+            })
+    score = (met / len(required)) * 100.0
+    return score, unmet
+
+
+def compute_relevant_sot_readiness(gate_cfg: dict, sot_scores: dict) -> tuple[float, list[dict]]:
+    relevant = gate_cfg.get("relevant_sots", [])
+    if not relevant:
+        return 100.0, []
+    usable = [(p, sot_scores[p]["score"]) for p in relevant if p in sot_scores]
+    if not usable:
+        return 0.0, [{
+            "dimension": "relevant_sot_readiness",
+            "reason": "No SoT file scores available — run compute-sot-readiness first.",
+            "severity": "high",
+            "fix": "Run compute-sot-readiness.py all before computing stage readiness.",
+        }]
+    mean = sum(s for _, s in usable) / len(usable)
+    unmet = [
+        {"dimension": "relevant_sot_readiness", "ref": p,
+         "reason": f"{p} scores {s} — drags down stage readiness.",
+         "severity": "medium" if s > 30 else "high",
+         "caused_by": p,
+         "caused_by_score": s,
+         "fix": f"Raise {p} to \u226570 to clear this dimension."}
+        for p, s in usable if s < 70
+    ]
+    return mean, unmet
+
+
+def compute_cross_ref_integrity(repo: Path, id_index: dict[str, set[str]],
+                                known_prefixes: set[str]) -> tuple[float, list[dict]]:
+    """Percentage of known-prefix references that resolve to a definition."""
+    defined: set[str] = set()
+    for ids in id_index.values():
+        defined |= ids
+
+    references: set[str] = set()
+    scan_files: list[Path] = []
+    for sub in ("SoT", "epics"):
+        p = repo / sub
+        if p.is_dir():
+            scan_files.extend(p.glob("*.md"))
+    for extra in ("PRD.md", "README.md"):
+        p = repo / extra
+        if p.is_file():
+            scan_files.append(p)
+
+    for f in scan_files:
+        for m in ID_RE.finditer(f.read_text(errors="replace")):
+            prefix = m.group(1)
+            if prefix not in known_prefixes:
+                continue
+            references.add(f"{prefix}-{m.group(2)}")
+
+    if not references:
+        return 100.0, []
+    dangling = references - defined
+    resolved = len(references) - len(dangling)
+    score = (resolved / len(references)) * 100.0
+
+    unmet = []
+    if dangling:
+        sample = sorted(dangling)[:5]
+        unmet.append({
+            "dimension": "cross_ref_integrity",
+            "reason": f"{len(dangling)} dangling ID reference(s) across repo: "
+                      f"{', '.join(sample)}" + ("..." if len(dangling) > 5 else ""),
+            "severity": "high" if len(dangling) > 5 else "medium",
+            "fix": "Define the referenced IDs, or remove the references.",
+        })
+    return score, unmet
+
+
+def compute_downstream_epic_readiness(gate_cfg: dict, epic_scores: dict) -> tuple[Optional[float], list[dict]]:
+    if not gate_cfg.get("enables_downstream_epic_readiness"):
+        return None, []
+    if not epic_scores:
+        return 0.0, [{
+            "dimension": "downstream_epic_readiness",
+            "reason": "No EPIC scores available for v0.7+ gate — EPICs must be scored before advancing.",
+            "severity": "high",
+            "fix": "Run compute-readiness.py on each EPIC before computing stage readiness.",
+        }]
+    scores = [e["score"] for e in epic_scores.values()]
+    mean = sum(scores) / len(scores)
+    below = [(eid, e["score"]) for eid, e in epic_scores.items() if e["score"] < 70]
+    unmet = [
+        {"dimension": "downstream_epic_readiness", "ref": eid,
+         "reason": f"{eid} scores {s} — below warn threshold (70).",
+         "severity": "high" if s < 50 else "medium",
+         "fix": f"Address unmet_criteria in {eid} before advancing stage."}
+        for eid, s in below
+    ]
+    return mean, unmet
+
+
+def renormalize(scores: dict[str, Optional[float]]) -> dict[str, float]:
+    active = {d: STAGE_WEIGHTS[d] for d in STAGE_WEIGHTS if scores.get(d) is not None}
+    total = sum(active.values())
+    return {d: w / total for d, w in active.items()} if total else {}
+
+
+def compute_stage(gate: str, repo: Path, readiness_json: dict) -> dict:
+    if gate not in GATE_REQUIREMENTS:
+        raise SystemExit(f"Unknown gate: {gate}. Supported: {', '.join(GATE_REQUIREMENTS)}")
+
+    gate_cfg = GATE_REQUIREMENTS[gate]
+    id_index = index_all_ids(repo)
+    sot_scores = readiness_json.get("sot_files", {})
+    epic_scores = readiness_json.get("epics", {})
+
+    dims: dict[str, dict] = {}
+    unmet: list[dict] = []
+
+    s, u = compute_required_ids_present(gate_cfg, id_index)
+    dims["required_ids_present"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_relevant_sot_readiness(gate_cfg, sot_scores)
+    dims["relevant_sot_readiness"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    # Known prefixes: union of what gate requires + what's defined + standard methodology prefixes
+    known_prefixes: set[str] = set(id_index.keys())
+    known_prefixes |= set(gate_cfg.get("required_prefixes", {}).keys())
+    for aliases in gate_cfg.get("prefix_aliases", {}).values():
+        known_prefixes |= set(aliases)
+    known_prefixes |= {"BR", "UJ", "PER", "SCR", "API", "DBT", "ENT", "TEST",
+                       "DEP", "RUN", "MON", "CFD", "DES", "TECH", "ARC", "INT",
+                       "RISK", "FEA", "GTM", "KPI", "EPIC", "LL"}
+
+    s, u = compute_cross_ref_integrity(repo, id_index, known_prefixes)
+    dims["cross_ref_integrity"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    s, u = compute_downstream_epic_readiness(gate_cfg, epic_scores)
+    dims["downstream_epic_readiness"] = {"score": round(s, 1) if s is not None else None}
+    unmet.extend(u)
+
+    score_map = {d: dims[d].get("score") for d in dims}
+    weights = renormalize(score_map)
+
+    weighted = 0.0
+    for d, w in weights.items():
+        dims[d]["weight"] = round(w, 3)
+        weighted += (score_map[d] or 0) * w
+
+    for d in dims:
+        if d not in weights:
+            dims[d]["status"] = "not_applicable"
+            dims[d].pop("score", None)
+
+    raw_penalty = sum(SEVERITY_PENALTY.get(c.get("severity", "medium"), 3) for c in unmet)
+    penalty = min(raw_penalty, MAX_PENALTY)
+
+    cap = 100
+    caps_applied: list[dict] = []
+    if score_map.get("required_ids_present", 100) < 50:
+        cap = 45
+        caps_applied.append({"rule": "missing_mandatory_artifacts", "cap": 45,
+                             "reason": "Too many required artifact types missing — gate cannot pass."})
+    if score_map.get("cross_ref_integrity", 100) < 60:
+        cap = min(cap, 60)
+        caps_applied.append({"rule": "cross_ref_broken", "cap": 60,
+                             "reason": "Many dangling references — repo integrity compromised."})
+
+    final = min(cap, max(0.0, weighted - penalty))
+
+    return {
+        "target": gate,
+        "work_type": "stage",
+        "gate_description": gate_cfg["name"],
+        "score": round(final, 1),
+        "weighted_score": round(weighted, 1),
+        "penalty": penalty,
+        "cap_applied": cap if caps_applied else None,
+        "caps": caps_applied,
+        "threshold_warn": 70,
+        "threshold_block": 50,
+        "dimensions": dims,
+        "unmet_criteria": unmet,
+    }
+
+
+# ---------- CLI ---------- #
+
+def main_cli() -> int:
+    p = argparse.ArgumentParser(description="Compute PRD stage readiness score.")
+    p.add_argument("--gate", type=str, default=None)
+    p.add_argument("--repo", type=Path, default=None)
+    p.add_argument("--output", type=str, default=None)
+    p.add_argument("--verbose", action="store_true")
+    args = p.parse_args()
+
+    repo = args.repo.resolve() if args.repo else find_repo_root(Path.cwd())
+    gate = args.gate or autodetect_gate(repo)
+    if not gate:
+        print("error: could not detect target gate — use --gate <vX.Y>.", file=sys.stderr)
+        return 2
+
+    readiness_file = repo / "status" / "readiness.json"
+    existing: dict = {}
+    if readiness_file.is_file():
+        try:
+            existing = json.loads(readiness_file.read_text())
+        except json.JSONDecodeError:
+            existing = {}
+
+    stage_block = compute_stage(gate, repo, existing)
+
+    output = dict(existing)
+    output["last_computed"] = datetime.now(timezone.utc).isoformat()
+    output["computed_by"] = f"compute-prd-readiness@{VERSION}"
+    output["schema_version"] = SCHEMA_VERSION
+    output.setdefault("stages", {})[gate] = stage_block
+
+    output["summary"] = build_summary(output)
+
+    out_json = json.dumps(output, indent=2, ensure_ascii=False)
+    if args.output == "-":
+        print(out_json)
+    else:
+        out_path = Path(args.output) if args.output else readiness_file
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(out_json + "\n")
+        if args.verbose:
+            print(f"wrote {out_path}")
+
+    if args.verbose:
+        print(f"\nStage {gate}: {stage_block['gate_description']}")
+        print(f"  score: {stage_block['score']}  (weighted {stage_block['weighted_score']}, "
+              f"penalty -{stage_block['penalty']}, cap {stage_block['cap_applied'] or 'none'})")
+        for d, info in stage_block["dimensions"].items():
+            if "status" in info:
+                print(f"  {d:<30} [{info['status']}]")
+            else:
+                print(f"  {d:<30} score={info['score']:>5}  weight={info.get('weight', 0):.3f}")
+        if stage_block["unmet_criteria"]:
+            print(f"\n  {len(stage_block['unmet_criteria'])} unmet:")
+            for c in stage_block["unmet_criteria"][:6]:
+                print(f"    - [{c['severity']}] {c.get('ref', c['dimension'])}: {c['reason'][:100]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/compute-prd-readiness.py
+++ b/scripts/compute-prd-readiness.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""PRD stage readiness scorer. See scripts/_readiness/stage.py for logic
+and docs/READINESS_PROTOCOL.md for the schema.
+
+Usage:
+  compute-prd-readiness.py [--gate vX.Y] [--repo PATH] [--output PATH] [--verbose]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _readiness.stage import main_cli
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/compute-readiness.py
+++ b/scripts/compute-readiness.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""EPIC readiness scorer. See scripts/_readiness/epic.py for logic
+and docs/READINESS_PROTOCOL.md for the schema.
+
+Usage:
+  compute-readiness.py <epic-file> [--inputs YAML] [--merge] [--repo PATH]
+                                   [--output PATH] [--verbose]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _readiness.epic import main_cli
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/compute-sot-readiness.py
+++ b/scripts/compute-sot-readiness.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""SoT file readiness scorer. See scripts/_readiness/sot.py for logic
+and docs/READINESS_PROTOCOL.md for the schema.
+
+Usage:
+  compute-sot-readiness.py <sot-file|all> [--repo PATH] [--output PATH] [--verbose]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _readiness.sot import main_cli
+
+if __name__ == "__main__":
+    sys.exit(main_cli())

--- a/scripts/readiness.py
+++ b/scripts/readiness.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+readiness.py — orchestrator for PRD-CE readiness scoring
+
+Composes three scoring layers into a single report:
+
+  SoT files    — per-file quality (entries, depth, cross-refs, orphans)
+  EPICs        — build-readiness per work package, cites SoT root causes
+  PRD stage    — can we advance v0.X → v0.Y? Composes SoT + EPIC scores
+
+All layers write to <repo>/status/readiness.json. Causal links connect
+the layers: an EPIC's score points at the SoT file blocking it; the SoT
+file's block lists which EPICs depend on it; the stage score composes
+both.
+
+Usage:
+  readiness.py run                # compute all layers, print report
+  readiness.py status             # print report from existing readiness.json
+  readiness.py run --json         # emit raw readiness.json to stdout
+
+Options:
+  --repo <path>    Repo root (default: cwd or autodetect)
+  --json           Emit JSON instead of the text report
+  --quiet          Suppress output; use exit code only
+  --gate <vX.Y>    Override target gate for stage scoring
+  --threshold <N>  Pass/warn threshold (default 70)
+
+Exit codes:
+  0  stage + all EPICs passing (score ≥ threshold)
+  1  at least one item in WARN band (score ≥ block, < warn)
+  2  at least one item in BLOCK band (score < block)
+  3  runtime error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SOT_SCRIPT = SCRIPT_DIR / "compute-sot-readiness.py"
+EPIC_SCRIPT = SCRIPT_DIR / "compute-readiness.py"
+STAGE_SCRIPT = SCRIPT_DIR / "compute-prd-readiness.py"
+
+BLOCK_THRESHOLD = 50
+DEFAULT_WARN_THRESHOLD = 70
+
+
+# ---------- Execution pipeline ---------- #
+
+def find_repo_root(start: Path) -> Path:
+    p = start.resolve()
+    if p.is_file():
+        p = p.parent
+    while p != p.parent:
+        if (p / "PRD.md").is_file() or (p / "SoT").is_dir() or (p / "epics").is_dir():
+            return p
+        p = p.parent
+    raise SystemExit("error: could not find repo root (no PRD.md, SoT/, or epics/ found)")
+
+
+def run_script(script: Path, args: list[str], cwd: Path, quiet: bool) -> int:
+    """Invoke a child script. Silence stdout unless --verbose is passed down."""
+    cmd = [sys.executable, str(script), *args]
+    if quiet:
+        result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    else:
+        result = subprocess.run(cmd, cwd=cwd, stdout=subprocess.DEVNULL, text=True)
+    if result.returncode != 0 and not quiet:
+        print(f"warning: {script.name} exited {result.returncode}", file=sys.stderr)
+        if result.stderr:
+            sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+def compute_all(repo: Path, gate_override: str | None, quiet: bool) -> None:
+    """Run the three scorers in dependency order: SoT → EPIC → Stage."""
+    # 1. SoT (primitive — others read its output)
+    run_script(SOT_SCRIPT, ["all"], repo, quiet)
+
+    # 2. EPICs (one per file, each merged into readiness.json)
+    epics_dir = repo / "epics"
+    pilot_inputs = repo / "temp" / "epic-01-readiness-inputs.yaml"
+    if epics_dir.is_dir():
+        for epic in sorted(epics_dir.glob("EPIC-*.md")):
+            if epic.name == "EPIC_TEMPLATE.md":
+                continue
+            args = [str(epic), "--merge"]
+            # Temporary pilot hook: if the EPIC has no readiness_inputs and
+            # a sibling temp file exists, load it. Drops away once frontmatter
+            # adoption lands.
+            if epic.name.startswith("EPIC-01") and pilot_inputs.is_file():
+                args.extend(["--inputs", str(pilot_inputs)])
+            run_script(EPIC_SCRIPT, args, repo, quiet)
+
+    # 3. Stage (reads SoT + EPIC scores to compose)
+    stage_args: list[str] = []
+    if gate_override:
+        stage_args.extend(["--gate", gate_override])
+    run_script(STAGE_SCRIPT, stage_args, repo, quiet)
+
+
+# ---------- Report formatting ---------- #
+
+def band(score: float, warn: int, block: int = BLOCK_THRESHOLD) -> str:
+    if score >= warn:
+        return "PASS"
+    if score >= block:
+        return "WARN"
+    return "BLOCK"
+
+
+def band_marker(score: float, warn: int) -> str:
+    b = band(score, warn)
+    return {"PASS": "✓", "WARN": "~", "BLOCK": "✗"}[b]
+
+
+def hr(char: str = "─", width: int = 72) -> str:
+    return char * width
+
+
+def format_report(readiness: dict, repo_name: str, warn: int) -> str:
+    lines: list[str] = []
+    lines.append(hr("━"))
+    lines.append(f"  PRD Readiness — {repo_name}")
+    lines.append(f"  {readiness.get('last_computed', 'n/a')}")
+    lines.append(hr("━"))
+    lines.append("")
+
+    summary = readiness.get("summary", {})
+
+    # STAGE section
+    stages = readiness.get("stages", {})
+    if stages:
+        lines.append("STAGE")
+        for gate, stage in sorted(stages.items()):
+            b = band(stage["score"], warn)
+            lines.append(f"  {gate}  score={stage['score']:<5}  [{b}]   {stage['gate_description']}")
+            unmet = stage.get("unmet_criteria", [])
+            if unmet:
+                high = [u for u in unmet if u.get("severity") == "high"]
+                for u in high[:3]:
+                    reason = u["reason"][:80] + ("..." if len(u["reason"]) > 80 else "")
+                    lines.append(f"    • [high] {reason}")
+                if len(high) > 3:
+                    lines.append(f"    • ... and {len(high) - 3} more high-severity")
+        lines.append("")
+
+    # EPIC section
+    epics = readiness.get("epics", {})
+    if epics:
+        passing = sum(1 for e in epics.values() if e["score"] >= warn)
+        lines.append(f"EPICs  ({passing}/{len(epics)} passing)")
+        # Sort by score ascending — worst first
+        sorted_epics = sorted(epics.items(), key=lambda kv: kv[1]["score"])
+        shown = 0
+        for eid, e in sorted_epics:
+            marker = band_marker(e["score"], warn)
+            cap_rules = ",".join(c.get("rule", "") for c in e.get("caps", []))
+            suffix = f"  [{cap_rules}]" if cap_rules else ""
+            if e["score"] < warn or shown < 3:
+                lines.append(f"  {marker} {eid}  score={e['score']:<5}  [{band(e['score'], warn)}]{suffix}")
+                shown += 1
+        if shown < len(epics):
+            lines.append(f"    (+ {len(epics) - shown} more passing)")
+        lines.append("")
+
+    # SoT LEVERAGE section
+    sot_files = readiness.get("sot_files", {})
+    blockers = summary.get("top_blockers", [])
+    if sot_files:
+        lines.append(f"SoT FILES  ({summary.get('sot_files_passing', 0)}/{summary.get('sot_files_total', len(sot_files))} passing)")
+        if blockers:
+            lines.append("  Top blockers (impact = (100-score) × #blocked EPICs):")
+            for b in blockers[:5]:
+                file_short = b["file"].replace("SoT/", "")
+                lines.append(f"    [{b['score']:>4}] {file_short:<34} blocks {b['blocks']:>2} EPIC(s)  impact={b['impact']:>5.0f}")
+        else:
+            lines.append("  No blockers — all SoT files passing.")
+        lines.append("")
+
+    # NEXT ACTIONS — the leverage view translated into a punch list
+    if blockers:
+        lines.append("NEXT ACTIONS  (highest leverage first)")
+        for i, b in enumerate(blockers[:3], 1):
+            file_short = b["file"].replace("SoT/", "")
+            consumers = b.get("blocking_epics", [])
+            consumer_str = f"{consumers[0]} and {len(consumers) - 1} others" if len(consumers) > 1 else consumers[0]
+            action = f"Populate {file_short}" if b["score"] == 0 else f"Raise {file_short} above {warn}"
+            lines.append(f"  {i}. {action} — unblocks {consumer_str}")
+        lines.append("")
+
+    # Overall verdict
+    current = summary.get("current_stage", {})
+    if current:
+        verdict_band = band(current["score"], warn)
+        lines.append(hr())
+        lines.append(f"  Current gate ({current['target']}): {current['score']}  [{verdict_band}]")
+        lines.append(hr())
+
+    return "\n".join(lines)
+
+
+def overall_exit_code(readiness: dict, warn: int) -> int:
+    """0=pass, 1=warn, 2=block, based on the worst-scored item across layers."""
+    worst = 100.0
+    for block in readiness.get("sot_files", {}).values():
+        worst = min(worst, block.get("score", 100))
+    for block in readiness.get("epics", {}).values():
+        worst = min(worst, block.get("score", 100))
+    for block in readiness.get("stages", {}).values():
+        worst = min(worst, block.get("score", 100))
+    if worst >= warn:
+        return 0
+    if worst >= BLOCK_THRESHOLD:
+        return 1
+    return 2
+
+
+# ---------- Main ---------- #
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="PRD-CE readiness scoring — orchestrates SoT, EPIC, and stage scorers.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Exit codes: 0=pass, 1=warn, 2=block, 3=error.",
+    )
+    p.add_argument("action", choices=["run", "status"], nargs="?", default="run",
+                   help="'run' computes all layers; 'status' prints latest from readiness.json.")
+    p.add_argument("--repo", type=Path, default=None)
+    p.add_argument("--gate", type=str, default=None,
+                   help="Override target gate (e.g. v0.8).")
+    p.add_argument("--threshold", type=int, default=DEFAULT_WARN_THRESHOLD,
+                   help=f"Warn threshold (default {DEFAULT_WARN_THRESHOLD}).")
+    p.add_argument("--json", dest="as_json", action="store_true",
+                   help="Emit readiness.json to stdout instead of the text report.")
+    p.add_argument("--quiet", action="store_true",
+                   help="Suppress all output; use exit code only.")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo = (args.repo.resolve() if args.repo else find_repo_root(Path.cwd()))
+    readiness_file = repo / "status" / "readiness.json"
+
+    if args.action == "run":
+        if not SOT_SCRIPT.is_file() or not EPIC_SCRIPT.is_file() or not STAGE_SCRIPT.is_file():
+            print(f"error: one or more scorer scripts missing next to {__file__}", file=sys.stderr)
+            return 3
+        compute_all(repo, args.gate, args.quiet)
+
+    if not readiness_file.is_file():
+        if not args.quiet:
+            print(f"error: {readiness_file} not found — run `readiness.py run` first.", file=sys.stderr)
+        return 3
+
+    readiness = json.loads(readiness_file.read_text())
+
+    if args.as_json:
+        print(json.dumps(readiness, indent=2, ensure_ascii=False))
+    elif not args.quiet:
+        print(format_report(readiness, repo.name, args.threshold))
+
+    return overall_exit_code(readiness, args.threshold)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,7 @@
+# Dependencies for scripts/readiness.py and the three scoring scripts.
+# Install: pip install -r scripts/requirements.txt
+
+pyyaml>=6.0
+
+# Dev/CI: test runner for tests/test_readiness.py
+pytest>=7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Pytest configuration and shared fixtures for readiness scoring tests."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the scripts/ directory importable so tests can reach `_readiness.*`.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def empty_repo(tmp_path: Path) -> Path:
+    """A minimal repo with placeholder SoT files — should score near 0."""
+    dst = tmp_path / "empty_repo"
+    shutil.copytree(FIXTURES_DIR / "empty_repo", dst)
+    return dst
+
+
+@pytest.fixture
+def healthy_repo(tmp_path: Path) -> Path:
+    """A well-populated repo — should score ≥ 70 on its current stage."""
+    dst = tmp_path / "healthy_repo"
+    shutil.copytree(FIXTURES_DIR / "healthy_repo", dst)
+    return dst

--- a/tests/fixtures/empty_repo/PRD.md
+++ b/tests/fixtures/empty_repo/PRD.md
@@ -1,0 +1,10 @@
+# Empty Repo · PRD
+
+| Field | Value |
+|---|---|
+| Current Lifecycle Gate | v0.7 |
+| Next Target Gate | v0.7 (Build) → v0.8 |
+
+## v0.7 Build Execution
+
+Placeholder.

--- a/tests/fixtures/empty_repo/SoT/SoT.API_CONTRACTS.md
+++ b/tests/fixtures/empty_repo/SoT/SoT.API_CONTRACTS.md
@@ -1,0 +1,3 @@
+# API Contracts (SoT File)
+
+*Pending PRD development*

--- a/tests/fixtures/empty_repo/SoT/SoT.BUSINESS_RULES.md
+++ b/tests/fixtures/empty_repo/SoT/SoT.BUSINESS_RULES.md
@@ -1,0 +1,3 @@
+# Business Rules (SoT File)
+
+*Pending PRD development*

--- a/tests/fixtures/empty_repo/SoT/SoT.TESTING.md
+++ b/tests/fixtures/empty_repo/SoT/SoT.TESTING.md
@@ -1,0 +1,3 @@
+# Testing (SoT File)
+
+*Pending PRD development*

--- a/tests/fixtures/empty_repo/epics/EPIC-01-bare.md
+++ b/tests/fixtures/empty_repo/epics/EPIC-01-bare.md
@@ -1,0 +1,20 @@
+---
+template_version: "3.3.0"
+readiness_inputs:
+  work_type: epic
+  depends_on_epics: []
+  required_tests: auto
+  threshold_warn: 70
+  threshold_block: 50
+---
+
+# EPIC-01 Bare
+
+> **State**: `Planned`
+
+## 3. Context & IDs
+
+| Type | IDs |
+| ---- | --- |
+| Business Rules | BR-001 (dangling) |
+| APIs | API-001 → API-003 (dangling) |

--- a/tests/fixtures/healthy_repo/PRD.md
+++ b/tests/fixtures/healthy_repo/PRD.md
@@ -1,0 +1,10 @@
+# Healthy Repo · PRD
+
+| Field | Value |
+|---|---|
+| Current Lifecycle Gate | v0.6 |
+| Next Target Gate | v0.6 (Architecture) → v0.7 |
+
+## v0.6 Architecture
+
+Stack selected; API contracts drafted.

--- a/tests/fixtures/healthy_repo/SoT/SoT.API_CONTRACTS.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.API_CONTRACTS.md
@@ -1,0 +1,22 @@
+# API Contracts (SoT File)
+
+## API-001 | GET /v1/items
+
+- **Purpose**: List items for the current user.
+- **Request**: query params `limit`, `offset`.
+- **Response**: JSON array of item objects; pagination headers.
+- **Related IDs**: [BR-001](SoT.BUSINESS_RULES.md#br-001) rate limit.
+
+## API-002 | POST /v1/items/:id/archive
+
+- **Purpose**: Archive an item. Irreversible; logged.
+- **Request**: path param `id`.
+- **Response**: 204 No Content on success.
+- **Related IDs**: [BR-002](SoT.BUSINESS_RULES.md#br-002) audit logging.
+
+## API-003 | GET /v1/health
+
+- **Purpose**: Service liveness probe.
+- **Request**: none.
+- **Response**: `{status: "ok"}` with 200, otherwise 503.
+- **Related IDs**: [ARC-001](SoT.TECHNICAL_DECISIONS.md#arc-001) architecture overview.

--- a/tests/fixtures/healthy_repo/SoT/SoT.BUSINESS_RULES.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.BUSINESS_RULES.md
@@ -1,0 +1,19 @@
+# Business Rules (SoT File)
+
+## BR-001 | Rate limit enforcement
+
+- **Rule Statement**: Free tier limited to 100 requests per day.
+- **Rationale**: Prevents abuse while allowing meaningful evaluation.
+- **Related IDs**: [API-001](SoT.API_CONTRACTS.md#api-001), [UJ-001](SoT.USER_JOURNEYS.md#uj-001).
+
+## BR-002 | Audit logging for sensitive actions
+
+- **Rule Statement**: Every destructive action writes an immutable audit log entry.
+- **Rationale**: Regulatory compliance and security forensics.
+- **Related IDs**: [API-002](SoT.API_CONTRACTS.md#api-002), [ARC-001](SoT.TECHNICAL_DECISIONS.md#arc-001).
+
+## BR-003 | Data residency
+
+- **Rule Statement**: User data must be stored in the region selected at signup.
+- **Rationale**: GDPR and data sovereignty requirements.
+- **Related IDs**: [ARC-001](SoT.TECHNICAL_DECISIONS.md#arc-001), [DBT-001](SoT.DATA_MODEL.md#dbt-001).

--- a/tests/fixtures/healthy_repo/SoT/SoT.DATA_MODEL.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.DATA_MODEL.md
@@ -1,0 +1,22 @@
+# Data Model (SoT File)
+
+## DBT-001 | Item
+
+- **Description**: Core user-owned record.
+- **Fields**: id (uuid), owner_id (uuid), created_at, archived_at (nullable), region.
+- **Relationships**: belongs_to User; has_many AuditLog entries.
+- **Related IDs**: [BR-003](SoT.BUSINESS_RULES.md#br-003) data residency.
+
+## DBT-002 | AuditLog
+
+- **Description**: Immutable append-only log of sensitive actions.
+- **Fields**: id, actor_id, action, target_id, timestamp, metadata JSON.
+- **Relationships**: belongs_to User (actor).
+- **Related IDs**: [BR-002](SoT.BUSINESS_RULES.md#br-002) audit logging.
+
+## DBT-003 | User
+
+- **Description**: Registered user with region preference and auth identity.
+- **Fields**: id (uuid), email, region, oauth_subject, created_at.
+- **Relationships**: has_many Item (DBT-001); has_many AuditLog (DBT-002).
+- **Related IDs**: [BR-003](SoT.BUSINESS_RULES.md#br-003), [TECH-003](SoT.TECHNICAL_DECISIONS.md#tech-003).

--- a/tests/fixtures/healthy_repo/SoT/SoT.RISKS.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.RISKS.md
@@ -1,0 +1,31 @@
+# Risks (SoT File)
+
+## RISK-001 | Rate-limit bypass via token rotation
+
+- **Description**: Free-tier users might rotate accounts to bypass BR-001 limit.
+- **Mitigation**: IP-based secondary limiter; rate-limit on signup.
+- **Related IDs**: [BR-001](SoT.BUSINESS_RULES.md#br-001).
+
+## RISK-002 | Audit log tampering
+
+- **Description**: Compromised service account could alter audit history.
+- **Mitigation**: Append-only table with trigger blocking UPDATE/DELETE; off-site replication.
+- **Related IDs**: [BR-002](SoT.BUSINESS_RULES.md#br-002), [DBT-002](SoT.DATA_MODEL.md#dbt-002).
+
+## RISK-003 | Regional outage causing cross-region reads
+
+- **Description**: If EU DB is down, app might fall back to US reads, violating BR-003.
+- **Mitigation**: Hard region checks in query layer; fail closed.
+- **Related IDs**: [BR-003](SoT.BUSINESS_RULES.md#br-003), [ARC-001](SoT.TECHNICAL_DECISIONS.md#arc-001).
+
+## RISK-004 | JWT secret leak
+
+- **Description**: Compromised signing key allows token forgery.
+- **Mitigation**: KMS-backed signing; short token lifetime; rotate quarterly.
+- **Related IDs**: [TECH-003](SoT.TECHNICAL_DECISIONS.md#tech-003).
+
+## RISK-005 | Team skills gap: JWT operations
+
+- **Description**: Team new to JWT lifecycle management.
+- **Mitigation**: Runbook + oncall training before launch.
+- **Related IDs**: [TECH-003](SoT.TECHNICAL_DECISIONS.md#tech-003).

--- a/tests/fixtures/healthy_repo/SoT/SoT.TECHNICAL_DECISIONS.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.TECHNICAL_DECISIONS.md
@@ -1,0 +1,26 @@
+# Technical Decisions (SoT File)
+
+## TECH-001 | Backend runtime: Node.js
+
+- **Decision**: Use Node.js 20 LTS for backend services.
+- **Rationale**: Strong ecosystem for HTTP services; aligns with team expertise.
+- **Alternatives Considered**: Go (faster compile/runtime but smaller hiring pool), Python (slower for hot paths).
+
+## TECH-002 | Database: PostgreSQL
+
+- **Decision**: PostgreSQL 16 via managed service.
+- **Rationale**: ACID guarantees needed for audit logs; team fluent in SQL.
+- **Alternatives Considered**: MongoDB (weaker consistency), DynamoDB (vendor lock-in).
+
+## TECH-003 | Auth: OAuth + JWT
+
+- **Decision**: OAuth 2.0 issuer + short-lived JWT access tokens.
+- **Rationale**: Standard pattern; avoids custom crypto.
+- **Alternatives Considered**: Session cookies (simpler but harder for mobile), custom tokens (NIH risk).
+
+## ARC-001 | Three-tier architecture
+
+- **Decision**: Web frontend → API gateway → service layer → PostgreSQL.
+- **Rationale**: Clear separation; allows independent scaling of layers.
+- **Alternatives Considered**: Monolith (faster to ship but harder to scale), event-driven (operational overhead not justified for MVP).
+- **Related IDs**: [BR-003](SoT.BUSINESS_RULES.md#br-003), [DBT-001](SoT.DATA_MODEL.md#dbt-001).

--- a/tests/fixtures/healthy_repo/SoT/SoT.TESTING.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.TESTING.md
@@ -1,0 +1,29 @@
+# Testing (SoT File)
+
+## TEST-001 | List items honors rate limit
+
+- **Given**: free-tier user with 100 requests already used today
+- **When**: user calls API-001 again
+- **Then**: 429 Too Many Requests; BR-001 enforced.
+- **Covers**: [API-001](SoT.API_CONTRACTS.md#api-001), [BR-001](SoT.BUSINESS_RULES.md#br-001).
+
+## TEST-002 | Archive writes audit log
+
+- **Given**: authenticated user and an unarchived item
+- **When**: user calls API-002 archive endpoint
+- **Then**: item archived; AuditLog entry created per BR-002; DBT-002 persisted.
+- **Covers**: [API-002](SoT.API_CONTRACTS.md#api-002), [BR-002](SoT.BUSINESS_RULES.md#br-002), [DBT-002](SoT.DATA_MODEL.md#dbt-002).
+
+## TEST-003 | Health endpoint returns 200 when DB reachable
+
+- **Given**: service running with DB connection
+- **When**: GET API-003 health endpoint
+- **Then**: 200 with `{status: "ok"}`.
+- **Covers**: [API-003](SoT.API_CONTRACTS.md#api-003).
+
+## TEST-004 | Data stored in selected region
+
+- **Given**: user signs up selecting EU region
+- **When**: user creates an item
+- **Then**: row persisted in EU database shard per BR-003.
+- **Covers**: [BR-003](SoT.BUSINESS_RULES.md#br-003), [DBT-001](SoT.DATA_MODEL.md#dbt-001).

--- a/tests/fixtures/healthy_repo/SoT/SoT.USER_JOURNEYS.md
+++ b/tests/fixtures/healthy_repo/SoT/SoT.USER_JOURNEYS.md
@@ -1,0 +1,22 @@
+# User Journeys (SoT File)
+
+## UJ-001 | List and archive an item
+
+- **Step 1**: user logs in
+- **Step 2**: user views items via API-001
+- **Step 3**: user archives an item via API-002 — audit logged per BR-002
+- **Related IDs**: [API-001](SoT.API_CONTRACTS.md#api-001), [API-002](SoT.API_CONTRACTS.md#api-002), [BR-002](SoT.BUSINESS_RULES.md#br-002).
+
+## UJ-002 | Sign up and select region
+
+- **Step 1**: user visits signup page
+- **Step 2**: user authenticates via OAuth (TECH-003)
+- **Step 3**: user selects storage region; account row persisted per BR-003
+- **Related IDs**: [BR-003](SoT.BUSINESS_RULES.md#br-003), [TECH-003](SoT.TECHNICAL_DECISIONS.md#tech-003), [DBT-003](SoT.DATA_MODEL.md#dbt-003).
+
+## UJ-003 | Monitor service health
+
+- **Step 1**: operator calls API-003 health endpoint
+- **Step 2**: response shows status + any degraded subsystems
+- **Step 3**: if degraded, oncall consults runbook
+- **Related IDs**: [API-003](SoT.API_CONTRACTS.md#api-003), [ARC-001](SoT.TECHNICAL_DECISIONS.md#arc-001).

--- a/tests/fixtures/healthy_repo/epics/EPIC-01-foundations.md
+++ b/tests/fixtures/healthy_repo/epics/EPIC-01-foundations.md
@@ -1,0 +1,27 @@
+---
+template_version: "3.3.0"
+readiness_inputs:
+  work_type: epic
+  depends_on_epics: []
+  required_tests: auto
+  threshold_warn: 70
+  threshold_block: 50
+  dimension_overrides:
+    confidence_avg: disabled
+    status_maturity: disabled
+---
+
+# EPIC-01 Foundations
+
+> **State**: `Planned`
+
+## 3. Context & IDs
+
+| Type | IDs |
+| ---- | --- |
+| Business Rules | BR-001, BR-002, BR-003 |
+| APIs | API-001, API-002, API-003 |
+| Data Models | DBT-001, DBT-002 |
+| Technical Decisions | TECH-001, TECH-002, TECH-003, ARC-001 |
+| Risks | RISK-001, RISK-002, RISK-003, RISK-004, RISK-005 |
+| User Journeys | UJ-001 |

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,160 @@
+"""Smoke tests for the readiness scoring pipeline.
+
+These run the same entry points a user would (`readiness.py run`) against
+deterministic fixture repos, then assert on the produced `status/readiness.json`.
+Keeps the test surface small — we're validating that the scoring machinery
+holds together, not that every formula is pinned to an exact number.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+READINESS_CLI = REPO_ROOT / "scripts" / "readiness.py"
+
+PASS_THRESHOLD = 70
+BLOCK_THRESHOLD = 50
+
+
+def run_readiness(repo: Path, extra_args: list[str] | None = None) -> tuple[int, dict]:
+    """Run `readiness.py run --quiet` in the fixture; return (exit_code, readiness_json)."""
+    cmd = [sys.executable, str(READINESS_CLI), "run", "--quiet"]
+    if extra_args:
+        cmd.extend(extra_args)
+    result = subprocess.run(cmd, cwd=repo, capture_output=True, text=True)
+    readiness_path = repo / "status" / "readiness.json"
+    data = json.loads(readiness_path.read_text()) if readiness_path.is_file() else {}
+    return result.returncode, data
+
+
+# ---------- Baseline scoring ---------- #
+
+def test_empty_repo_scores_low(empty_repo: Path) -> None:
+    """Placeholder SoTs + dangling refs → stage BLOCK, every SoT at 0."""
+    exit_code, data = run_readiness(empty_repo)
+    assert exit_code == 2, f"expected BLOCK exit 2, got {exit_code}"
+
+    stage = data["summary"]["current_stage"]
+    assert stage["score"] < BLOCK_THRESHOLD, f"empty repo stage scored {stage['score']}"
+    assert not stage["passing"]
+
+    # Every SoT file should be a placeholder (score 0)
+    for path, block in data["sot_files"].items():
+        assert block["score"] == 0, f"{path} unexpectedly scored {block['score']}"
+
+
+def test_healthy_repo_scores_above_warn(healthy_repo: Path) -> None:
+    """Well-populated repo with resolved refs + tests → stage PASS."""
+    exit_code, data = run_readiness(healthy_repo)
+    assert exit_code == 0, f"expected PASS exit 0, got {exit_code}"
+
+    stage = data["summary"]["current_stage"]
+    assert stage["score"] >= PASS_THRESHOLD, f"healthy repo stage scored {stage['score']}"
+    assert stage["passing"]
+
+    # Every EPIC should pass the warn threshold
+    for eid, block in data["epics"].items():
+        assert block["score"] >= PASS_THRESHOLD, f"{eid} scored {block['score']}"
+
+
+# ---------- Specific defect detection ---------- #
+
+def test_dangling_ref_surfaces_as_spec_resolution_unmet(healthy_repo: Path) -> None:
+    """Deleting a referenced SoT entry should produce a spec_resolution unmet criterion
+    with `caused_by` pointing at the owning file."""
+    api_file = healthy_repo / "SoT" / "SoT.API_CONTRACTS.md"
+    text = api_file.read_text()
+    # Remove API-002 entirely
+    patched = text.split("## API-002")[0] + "## API-003" + text.split("## API-003", 1)[1]
+    api_file.write_text(patched)
+
+    _, data = run_readiness(healthy_repo)
+    epic_block = next(iter(data["epics"].values()))
+    spec_res_unmet = [c for c in epic_block["unmet_criteria"]
+                      if c["dimension"] == "spec_resolution"]
+    assert any(c.get("ref") == "API-002" for c in spec_res_unmet), \
+        f"expected API-002 dangling; got {[c.get('ref') for c in spec_res_unmet]}"
+    # The unmet should cite the owning SoT file
+    api_002_unmet = next(c for c in spec_res_unmet if c.get("ref") == "API-002")
+    assert api_002_unmet.get("caused_by") == "SoT/SoT.API_CONTRACTS.md"
+
+
+def test_stub_testing_file_triggers_cap(healthy_repo: Path) -> None:
+    """Replacing SoT.TESTING.md with a placeholder triggers the test_coverage_zero cap."""
+    testing_file = healthy_repo / "SoT" / "SoT.TESTING.md"
+    testing_file.write_text("# Testing\n\n*Pending PRD development*\n")
+
+    _, data = run_readiness(healthy_repo)
+    epic_block = next(iter(data["epics"].values()))
+    cap_rules = [c["rule"] for c in epic_block["caps"]]
+    assert "test_coverage_zero" in cap_rules, f"expected cap; got {cap_rules}"
+
+    # The cap should cite SoT.TESTING.md specifically
+    test_cap = next(c for c in epic_block["caps"] if c["rule"] == "test_coverage_zero")
+    assert test_cap["caused_by"] == "SoT/SoT.TESTING.md"
+    assert test_cap["caused_by_score"] == 0
+
+
+def test_cross_layer_causal_links(healthy_repo: Path) -> None:
+    """Every EPIC caused_by pointer must match a real sot_files key; every SoT
+    file's consumed_by_epics must reference real EPIC keys. This is what makes
+    the graph traversable."""
+    _, data = run_readiness(healthy_repo)
+    sot_paths = set(data["sot_files"].keys())
+    epic_ids = set(data["epics"].keys())
+
+    for eid, epic in data["epics"].items():
+        for cap in epic.get("caps", []):
+            if cap.get("caused_by"):
+                assert cap["caused_by"] in sot_paths, \
+                    f"{eid} cap cites unknown SoT: {cap['caused_by']}"
+        for c in epic.get("unmet_criteria", []):
+            if c.get("caused_by"):
+                assert c["caused_by"] in sot_paths, \
+                    f"{eid} unmet cites unknown SoT: {c['caused_by']}"
+
+    for path, block in data["sot_files"].items():
+        for consumer in block.get("consumed_by_epics", []):
+            assert consumer in epic_ids, \
+                f"{path} lists unknown consumer: {consumer}"
+
+
+def test_dimension_override_disabled(healthy_repo: Path) -> None:
+    """A dimension listed in dimension_overrides should be marked disabled in output,
+    and the remaining weights should renormalize to sum ≈ 1.0."""
+    _, data = run_readiness(healthy_repo)
+    epic_block = next(iter(data["epics"].values()))
+    dims = epic_block["dimensions"]
+
+    # confidence_avg and status_maturity are disabled in the fixture EPIC
+    assert dims["confidence_avg"].get("status") == "disabled", dims["confidence_avg"]
+    assert dims["status_maturity"].get("status") == "disabled", dims["status_maturity"]
+
+    # Active weights should sum to approximately 1.0
+    active_weights = sum(d.get("weight", 0) for d in dims.values() if "weight" in d)
+    assert abs(active_weights - 1.0) < 0.01, \
+        f"weights sum to {active_weights}, expected ~1.0 after renormalization"
+
+
+# ---------- Summary block ---------- #
+
+def test_summary_top_blockers_ranking(empty_repo: Path) -> None:
+    """When multiple SoT files are at 0, top_blockers should rank by (100-score) × #blocked."""
+    _, data = run_readiness(empty_repo)
+    blockers = data["summary"]["top_blockers"]
+    # Should list SoT.TESTING.md or other 0-scored files with EPIC consumers
+    assert len(blockers) > 0, "expected at least one top blocker in empty repo"
+    # Ranking: impact descending
+    impacts = [b["impact"] for b in blockers]
+    assert impacts == sorted(impacts, reverse=True), f"not sorted by impact: {impacts}"
+    # Impact formula holds
+    for b in blockers:
+        expected = (100 - b["score"]) * b["blocks"]
+        assert abs(b["impact"] - expected) < 0.5, f"impact mismatch on {b['file']}"


### PR DESCRIPTION
## Summary

Adds a **three-layer readiness scoring** system to PRD-CE: SoT files → EPICs → PRD stages. One repo, one `status/readiness.json`, one orchestrator (`scripts/readiness.py run`), causal links across layers so an EPIC's cap cites the SoT file that caused it and each SoT file lists its consumer EPICs.

The leverage view is the point. Today's binary `ghm-gate-check` tells you "blocked" or "advance" — this tells you *what's blocking you, ranked by how many downstream EPICs it unblocks*. On the OriginStamp pilot, 8 EPICs stuck at WARN collapsed to one root cause: an empty `SoT.TESTING.md` (impact 800). Fix that one file, eight EPICs advance.

**What ships:**
- `scripts/_readiness/` Python package (common + sot/epic/stage modules) — ~1700 lines of scoring logic; three `compute-*.py` CLIs shrunk to 17-line wrappers.
- `scripts/readiness.py` orchestrator — `run` / `status`, `--json`, `--quiet`, exit codes 0/1/2/3.
- `docs/READINESS_PROTOCOL.md` — full schema reference (inputs, JSON output, dimensions, penalty math, critical caps, extension guide).
- `.claude/rules/07-readiness-protocol.md` — the discipline rule (matches rule 01/03/06 shape).
- README.md "Readiness Scoring" section between Documentation Ecosystem and Progressive PRD.
- `EPIC_TEMPLATE.md` → 3.3.0 with `readiness_inputs:` frontmatter (~5 lines per EPIC).
- `ghm-gate-check` skill **evolved** to delegate to `readiness.py`; `references/gate-criteria.md` unchanged and still canonical (now consumed by `_readiness/stage.py::GATE_REQUIREMENTS`).
- `tests/` establishes pytest precedent — 7 smoke tests, 2 fixture repos, ~1.5s runtime.
- `.github/workflows/readiness.yml` runs pytest + non-blocking self-scoring.

**Design decisions documented in commit message:** computed-not-declared, soft-gate (warn not block), separate schemas per work type, hybrid storage (declared inputs in markdown frontmatter, computed output in JSON), severity-weighted penalties with `MAX_PENALTY=25` cap, critical-dimension caps for categorical failures.

**Explicitly deferred** (follow-up PRs): hook implementation (PostToolUse sync + PreToolUse warn), PR-comment automation, multi-repo calibration pass, migration script to backfill `readiness_inputs` on existing EPICs in downstream repos.

## Test plan

- [x] `pytest tests/` green locally (7/7 pass in 1.5s)
- [x] `scripts/readiness.py run` on OriginStamp pilot scores stage v0.8 at 36.6 BLOCK (matches pre-refactor baseline; JSON byte-identical modulo timestamps)
- [x] Refactor preserves exact output — `_readiness` package produces identical `readiness.json` to the pre-split scripts
- [x] Fresh EPIC from template 3.3.0 scores cleanly
- [x] Evolved `ghm-gate-check` report matches the template shape in `references/examples.md`
- [ ] GitHub Actions workflow runs green on this PR (tests job pins the scoring engine; smoke job is non-blocking)
- [ ] Reviewer sanity-check on `docs/READINESS_PROTOCOL.md` — every field in the example `readiness.json` is documented
- [ ] Reviewer sanity-check that `rule 07` fits the discipline-rule voice (terse, bullets, no tutorial prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)