### PR TITLE
feat: Development Graph — bridge spec IDs to as-built code (v0.6/v0.7)

### DIFF
--- a/.claude/domain-profile.yaml
+++ b/.claude/domain-profile.yaml
@@ -47,6 +47,32 @@ id_prefixes:
   # Execution IDs
   EPIC: { file: "epics/",    description: "Execution work packages" }
 
+# --- Development Graph: Code Node Types (v0.6→v0.7) ---
+# The "as-built" layer of the knowledge graph. Unlike id_prefixes (hand-authored
+# spec nodes), these are entities EXTRACTED from the product codebase during v0.7
+# build execution — Graphify-style AST parsing, deterministic and free (no LLM).
+# They are NOT ID-prefixed; their identity is `{parent_dir}_{file}_{symbol}`.
+# See docs/DEVELOPMENT_GRAPH.md for the full schema (the HeartBeat data contract).
+code_node_types:
+  module:   { description: "A source file or package" }
+  class:    { description: "A class / type / interface definition" }
+  function: { description: "A function or method" }
+  table:    { description: "A database table (from SQL DDL or ORM model)" }
+  endpoint: { description: "An HTTP route / API handler" }
+
+# --- Development Graph: Bridge Relations (v0.6→v0.7) ---
+# Edges that connect the CODE layer to the SPEC (ID) layer. Harvested from the
+# @implements / @see / @verifies traceability tags mandated by rule 04, plus
+# TEST- references. These bridge edges are what let readiness measure
+# build-vs-blueprint (implementation_coverage) and architecture drift
+# (architecture_conformance). `confidence` follows the Graphify audit trail:
+# EXTRACTED (explicit tag, 1.0) | INFERRED (name/context match) | AMBIGUOUS (review).
+bridge_relations:
+  implements: { from: code, to: spec, source: "@implements tag",     description: "Code node realizes a spec ID" }
+  verifies:   { from: code, to: spec, source: "@verifies / TEST- ref", description: "Test node checks a spec ID" }
+  references: { from: code, to: spec, source: "@see tag",            description: "Code node relates to a spec ID without implementing it" }
+  violates:   { from: code, to: spec, source: "conformance diff",     description: "Code node breaks an ARC- rule (architecture drift)" }
+
 # --- Skill Taxonomy ---
 # Core skills work in any domain. Domain skills are product-specific.
 skills:

--- a/.claude/rules/04-coding-standards.md
+++ b/.claude/rules/04-coding-standards.md
@@ -11,9 +11,13 @@ Every major code unit must declare which ID it implements.
 ```typescript
 // @implements BR-101 (Free Limit)
 // @see API-045
+// @verifies BR-101   (on the test that checks it)
 export class RateLimiter { ... }
 ```
+
+These tags are not just comments — in v0.7 they are **harvested into the Development Graph** (`status/devgraph.json`) as bridge edges (`implements` / `verifies` / `references`) linking each code unit to the spec ID it realizes. That graph is what readiness uses to measure build-vs-blueprint (`implementation_coverage`) and what the HeartBeat visualizer renders. Untagged code shows up as an `orphan` node — a context leak. See [`docs/DEVELOPMENT_GRAPH.md`](../../docs/DEVELOPMENT_GRAPH.md).
 
 - **Tests First**: Create/Update tests (`TEST-`) for every feature.
 - **No Secrets**: Never commit credentials.
 - **Small Commits**: Group changes by ID/Feature.
+- **Tag Everything**: Every major unit carries `@implements`; tests carry `@verifies`. No orphan code.

--- a/.claude/rules/07-readiness-protocol.md
+++ b/.claude/rules/07-readiness-protocol.md
@@ -5,6 +5,7 @@ alwaysApply: true
 # Readiness Protocol
 
 - **Three layers**: SoT files (primitive) → EPICs (compose SoT) → PRD stage (composes both). All scores write to `status/readiness.json`.
+- **Code layer (v0.6→v0.7)**: once a build produces `status/devgraph.json`, two EPIC dimensions activate — `implementation_coverage` (scoped specs with implementing code) and `architecture_conformance` (`ARC-` rules that still hold) — plus an `unbuilt_specs` cap. They auto-disable before build, so pre-v0.7 scores are unaffected. Schema: `docs/DEVELOPMENT_GRAPH.md`.
 - **Compute**: Run `python scripts/readiness.py run` to refresh. Output survives in `status/readiness.json` with `last_computed` timestamp.
 - **Inspect**: `readiness.py status` (text report) or `readiness.py status --json` (machine-readable).
 - **Thresholds**: `score ≥ 70` PASS, `50–69` WARN, `< 50` BLOCK. Exit codes 0/1/2 match.

--- a/.claude/skills/prd-v06-architecture-design/SKILL.md
+++ b/.claude/skills/prd-v06-architecture-design/SKILL.md
@@ -34,6 +34,7 @@ This skill creates/updates:
 - **ARC-\* entries** (architecture decisions, status-based) — Decisions for structure, integration, security, performance, data, DevOps with rationale, alternatives considered, and consequences. No confidence scores; decisions have Status: Proposed/Accepted/Superseded
 - **System boundary diagram** — Visual representation showing trust boundaries, components, and external integrations
 - **RISK-to-Architecture mapping** — Validation showing every high-priority RISK-* has corresponding ARC-* mitigation or explicit acceptance
+- **Conformance rules (on ARC- entries)** — for any decision that makes a structural claim ("X must not depend on Y", "all Z go through one adapter"), a machine-checkable rule. This turns the architecture into the *expected topology* (the blueprint graph) the v0.7 build is diffed against, and feeds the `architecture_conformance` readiness dimension. See `docs/DEVELOPMENT_GRAPH.md`.
 
 All ARC- entries should include:
 - **Category**: Structure/Integration/Security/Performance/Data/DevOps
@@ -213,6 +214,11 @@ Consequences:
   - Enables: [What this makes possible]
   - Constrains: [What this limits]
 
+Conformance Rule (optional — for structural claims):
+  - Rule: [e.g. "engine/ must not import the UI framework"]
+  - Check: [type · scope · target, e.g. forbidden_import · engine/** · vscode]
+  (verified against the as-built code in v0.7 → architecture_conformance; see docs/DEVELOPMENT_GRAPH.md)
+
 Related IDs: [TECH-XXX, RISK-XXX, FEA-XXX]
 Status: [Proposed | Accepted | Superseded]
 ```
@@ -339,6 +345,7 @@ ARC- entries feed into:
 |----------|--------------|---------|
 | **Technical Specification** | ARC- informs API design | ARC-001 (monolith) → unified API surface |
 | **v0.7 Build Execution** | ARC- defines EPIC scope | ARC-003 (auth module) → EPIC-02 |
+| **Development Graph (v0.7)** | ARC- conformance rules become code checks | ARC-004 (no UI import in engine/) → `architecture_conformance` verdict |
 | **Infrastructure Setup** | ARC- drives deployment | ARC-010 (edge caching) → CDN config |
 | **Security Review** | Security ARC- entries | ARC-005 → pen test scope |
 

--- a/.claude/skills/prd-v07-implementation-loop/SKILL.md
+++ b/.claude/skills/prd-v07-implementation-loop/SKILL.md
@@ -35,6 +35,7 @@ This skill updates/creates:
 - **Working code** (implementation of API-, DBT-, BR-, tested against TEST-) — Runnable code with @implements tags tracing back to specifications; passes all TEST- for EPIC
 - **Updated SoT entries** (if implementation reveals changes) — When building reveals new constraints or edge cases, update API-/DBT-/BR- entries immediately (not deferred)
 - **Session State updates** (EPIC.md Section 1) — "Brain dump" tracking exact stopping point, Next Steps for resume, blockers, decisions, Context
+- **Development Graph** (`status/devgraph.json`) — the `@implements`/`@verifies` tags you write are harvested into bridge edges, producing the as-built layer that readiness scores (`implementation_coverage`, `architecture_conformance`) and the **HeartBeat** visualizer renders. Schema: `docs/DEVELOPMENT_GRAPH.md`.
 
 All implementation outputs are **code and live SoT**, not confidence-based. They are:
 - **Traceable** (every function tagged with @implements pointing to specification ID)
@@ -99,6 +100,8 @@ Example Session State update (EPIC-01 mid-session):
 ## This skill executes the build. It's the iterative cycle of: **Load Context → Test → Code → Tag → Update → Validate → Repeat**.
 
 ## The Core Loop (The Heartbeat)
+
+Each pass leaves a trace: step 5 tags code with `@implements`, and those tags are exactly what the **Development Graph** harvests — so this loop literally produces the pulse the **HeartBeat** visualizer shows (built → 🟢, unbuilt → 🔴, drifted → 🔴). Rerun `readiness.py run` after a Context Window to watch `implementation_coverage` move.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -432,6 +435,7 @@ Before marking EPIC complete:
 - [ ] Session State is clean
 - [ ] Manual UJ- verification done
 - [ ] Change Log updated
+- [ ] Development Graph green — `status/devgraph.json` rebuilt; `implementation_coverage` ≥ threshold (no scoped spec unbuilt, no `unbuilt_specs` cap) and no `architecture_conformance` violations
 
 ## Downstream Connections
 
@@ -441,6 +445,8 @@ Implementation Loop outputs feed into:
 |----------|--------------|---------|
 | **v0.8 Release** | Completed EPICs ready for deployment | All TEST- pass, SoT current |
 | **Code Review** | @implements tags for context | Reviewer knows which BR- to check |
+| **Readiness (v0.7)** | Development Graph build-vs-blueprint | `implementation_coverage` + `architecture_conformance` from `status/devgraph.json` |
+| **HeartBeat** | The Development Graph as a live pulse | Renders built / unbuilt / drifted across the codebase |
 | **Future Sessions** | Session State for continuity | Resume exactly where left off |
 | **Maintenance** | Traceability for debugging | "Which BR- does this code implement?" |
 

--- a/PRD.md
+++ b/PRD.md
@@ -224,6 +224,13 @@ template_version: "3.0.0"
 
 - External dependencies, rate limits, compliance.
 
+**Development Graph — Expected Topology**
+
+The architecture recorded here is the *blueprint graph* — the intended shape the build must match in v0.7. Capture it so the as-built code can be diffed against it:
+
+- **Expected components & boundaries** — the System Overview above, read as a topology: which modules/services exist and which may depend on which.
+- **Conformance rules (on ARC- entries)** — structural claims the code can be checked against, e.g. _"the `engine/` layer must not import the UI framework."_ Each becomes a machine verdict (`pass`/`violate`) feeding the `architecture_conformance` readiness dimension. See `SoT/SoT.TECHNICAL_DECISIONS.md` and [`docs/DEVELOPMENT_GRAPH.md`](docs/DEVELOPMENT_GRAPH.md).
+
 **Outstanding Work → v0.7**
 
 - {Implementation open question}
@@ -242,11 +249,16 @@ template_version: "3.0.0"
 - TEST-### — {Scope}
 - TEST-### — {Scope}
 
+**Development Graph (As-Built)**
+
+During the implementation loop, the `@implements` / `@verifies` tags on each code unit are harvested into the Development Graph (`status/devgraph.json`), bridging the code back to the specs above. This is what lets readiness measure build-vs-blueprint (`implementation_coverage`) and architecture drift (`architecture_conformance`) — and is the data the **HeartBeat** visualizer renders. See [`docs/DEVELOPMENT_GRAPH.md`](docs/DEVELOPMENT_GRAPH.md).
+
 **Definition of Done**
 
 - [ ] All IDs created/modified logged in EPIC Section 2.
 - [ ] README metrics updated via workflow.
 - [ ] Coverage thresholds defined.
+- [ ] Code traced to specs — every major unit carries `@implements`; `status/devgraph.json` rebuilt; `implementation_coverage` ≥ threshold (no scoped spec left unbuilt).
 
 ### Deployment Configuration
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Readiness scoring is a **three-layer graph** over the artifacts you already auth
 
 All three layers write to one file: `status/readiness.json`. The causal links stay in the JSON — an EPIC's unmet criterion points at its `caused_by` SoT file; a SoT file's block lists its `consumed_by_epics`; the top-level `summary.top_blockers` ranks files by downstream impact. This is the leverage view: the highest-impact fix might not be the lowest-scoring file — it's the lowest-scoring file blocking the most EPICs.
 
+### The code layer (v0.6 → v0.7)
+
+The three layers above score the *specs* you author. Once building starts, a fourth artifact appears — the code itself — and the **Development Graph** folds it into the same knowledge graph. A Graphify-style AST pass extracts code nodes (modules, functions, tables); the `@implements` / `@verifies` tags you already write ([rule 04](.claude/rules/04-coding-standards.md)) are harvested into **bridge edges** linking each code unit back to the spec ID it realizes. Readiness then gains two build-vs-blueprint dimensions — `implementation_coverage` (which scoped specs have implementing code) and `architecture_conformance` (do the `ARC-` rules still hold in the as-built code) — backed by `status/devgraph.json`. This is what makes v0.7 readiness measure *reality*, not just spec health. The same `devgraph.json` is the data contract the **HeartBeat** visualizer renders as a live pulse of built / unbuilt / drifted. See [`docs/DEVELOPMENT_GRAPH.md`](docs/DEVELOPMENT_GRAPH.md).
+
 ### Invocation
 
 ```bash
@@ -175,6 +179,7 @@ Exit codes: `0` all pass, `1` something in WARN band, `2` something in BLOCK ban
 
 - [`.claude/rules/07-readiness-protocol.md`](.claude/rules/07-readiness-protocol.md) — the discipline rule.
 - [`docs/READINESS_PROTOCOL.md`](docs/READINESS_PROTOCOL.md) — full schema reference: `readiness_inputs` YAML shape, `readiness.json` structure, every dimension with its formula, penalty math, critical caps, and how to extend it.
+- [`docs/DEVELOPMENT_GRAPH.md`](docs/DEVELOPMENT_GRAPH.md) — the v0.6→v0.7 code layer: `status/devgraph.json` schema, the spec/code/bridge model, and the HeartBeat data contract.
 <!-- /SECTION: readiness-scoring -->
 
 ---
@@ -203,8 +208,8 @@ We do not proceed to the next stage until the **Definition of Done (DoD)** is me
 | **v0.3** | **Commercial Model**     | Value & Pricing       | Competitors profiled, Pricing model, Monetization rules.           |
 | **v0.4** | **User Journeys**        | Personas & Flows      | Core journeys mapped (`UJ-`), Dependencies (`API-`) noted.         |
 | **v0.5** | **Red Team Review**      | Risks & Feasibility   | Risks (Market/Tech) identified, Mitigations linked to tests.       |
-| **v0.6** | **Architecture**         | Technical Strategy    | Stack selected, API contracts (`API-`) drafted, Cost guardrails.   |
-| **v0.7** | **Build Execution**      | Implementation Loop   | Code tested (`TEST-`), SoT updated, Epic loop execution.           |
+| **v0.6** | **Architecture**         | Technical Strategy    | Stack selected, API contracts (`API-`) drafted, `ARC-` conformance rules, Cost guardrails. |
+| **v0.7** | **Build Execution**      | Implementation Loop   | Code tested (`TEST-`), SoT updated, code traced to specs (Development Graph), Epic loop execution. |
 | **v0.8** | **Release & Deployment** | Operational Readiness | Runbooks (`RUN-`), Monitoring (`MON-`), Rollback plan.             |
 | **v0.9** | **Launch**               | Go-to-Market          | Launch metrics (`KPI-`), Feedback channels (`CFD-`) active.        |
 | **v1.0** | **Growth**               | Market Adoption       | Paying customers, Retention analysis, Optimization loop.           |

--- a/SoT/SoT.README.md
+++ b/SoT/SoT.README.md
@@ -34,6 +34,8 @@ Each file focuses on one artifact type with a consistent ID prefix (~100-150 lin
 
 > See [SoT.UNIQUE_ID_SYSTEM.md](SoT.UNIQUE_ID_SYSTEM.md) for full ID specifications.
 
+> **The as-built layer (v0.7)**: the IDs in these files are the *spec* layer of the knowledge graph. During build execution the product's code becomes a second layer — extracted into `status/devgraph.json` and bridged back to these IDs via the `@implements` tags in code. The IDs you define here are the anchors those bridges point to; an `ARC-` entry can carry a **Conformance Rule** the code is checked against. See [`../docs/DEVELOPMENT_GRAPH.md`](../docs/DEVELOPMENT_GRAPH.md).
+
 ## How to Initialize
 
 1. Fork this repository for your product

--- a/SoT/SoT.TECHNICAL_DECISIONS.md
+++ b/SoT/SoT.TECHNICAL_DECISIONS.md
@@ -1,8 +1,8 @@
 ---
-version: 1.1
+version: 1.2
 purpose: Source of Truth for technology choices, architecture decisions, and environment specifications.
 id_prefix: TECH-XXX, ARC-XXX, ENV-XXX
-last_updated: 2026-01-18
+last_updated: 2026-06-06
 authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and code
 ---
 <!-- SECTION: template-structure -->
@@ -81,6 +81,14 @@ authority: This is a SoT file - IDs here are referenced by PRD.md, EPICs, and co
 - **Chosen because**: {Primary reasons}
 - **Alternatives considered**: {What else was evaluated}
 - **Consequences**: {What this enables or constrains}
+
+### Conformance Rule (optional)
+
+A machine-checkable restatement of this decision, evaluated against the as-built code in the Development Graph (`status/devgraph.json`). When present it drives the `architecture_conformance` readiness dimension — the code is verified to still honor the decision, and drift surfaces as a `violate` verdict instead of slipping by unnoticed.
+
+- **Rule**: {plain statement, e.g. "the `engine/` layer must not import the UI framework"}
+- **Check**: {type · scope · target, e.g. `forbidden_import` · `packages/extension/engine/**` · `vscode`}
+- **Verdict**: `pass` | `violate` | `unknown` (computed — see [`docs/DEVELOPMENT_GRAPH.md`](../docs/DEVELOPMENT_GRAPH.md) §5)
 
 ### Related IDs
 
@@ -329,6 +337,7 @@ When adding a new TECH/ARC/ENV-XXX:
 - [ ] Update related API contracts if affected
 - [ ] Update EPIC Section 2 "Context & IDs" list
 - [ ] Update SoT.UNIQUE_ID_SYSTEM.md registry if maintained
+- [ ] For an ARC- that makes a structural claim, add a **Conformance Rule** so the Development Graph can verify the as-built code honors it (v0.7)
 
 ---
 

--- a/docs/DEVELOPMENT_GRAPH.md
+++ b/docs/DEVELOPMENT_GRAPH.md
@@ -1,0 +1,321 @@
+# Development Graph — Schema Reference & HeartBeat Data Contract
+
+**Status**: v0.1 (draft) · schema_version `0.1` · last revised 2026-06-06
+
+The **Development Graph** is the "as-built" layer of the PRD-CE knowledge graph. Where the ID graph (`BR-`, `UJ-`, `API-`, `ARC-`…) is **top-down intent** authored before code exists, the Development Graph is **bottom-up structure** extracted from the product codebase during v0.7 build execution. Bridging the two — via the `@implements` / `@verifies` traceability tags mandated by [rule 04](../.claude/rules/04-coding-standards.md) — lets the repo measure *build-vs-blueprint*: which specs have code, which code has no spec, and where the code has drifted from a recorded architecture decision.
+
+This file is the canonical schema for `status/devgraph.json`. It is also the **data contract** consumed by **HeartBeat**, the visual expression of this graph. HeartBeat owns rendering (force-directed layout, community color, god-node sizing — techniques borrowed from [Graphify](https://github.com/safishamsi/graphify)); this repo owns producing the data described here. Anything HeartBeat renders must be defined in this document.
+
+> **Companion docs**: [`READINESS_PROTOCOL.md`](READINESS_PROTOCOL.md) (the scorecard that consumes this graph), [`.claude/rules/07-readiness-protocol.md`](../.claude/rules/07-readiness-protocol.md) (the discipline rule), [`.claude/domain-profile.yaml`](../.claude/domain-profile.yaml) (`code_node_types` + `bridge_relations`).
+
+---
+
+## 1. The three layers
+
+The graph is one connected structure spanning three node layers. The `layer` field on every node says which it belongs to.
+
+| Layer | `layer` value | Nodes | Source | Authored by | Graphify analog |
+|---|---|---|---|---|---|
+| **Spec** | `spec` | ID-prefixed specs (`BR-001`, `API-045`, `ARC-004`…) | SoT/PRD ID graph | Humans + agents (v0.1–v0.6) | `document` / `concept` nodes |
+| **Code** | `code` | modules, classes, functions, tables, endpoints | AST extraction (tree-sitter), **free, no LLM** | Extractor (v0.7) | `code` nodes |
+| **Bridge** | — (edges only) | `implements`, `verifies`, `references`, `violates` edges | `@implements`/`@see`/`@verifies` tags + conformance diff | Code authors via tags | `implements` / `references` edges |
+
+The spec layer already exists as the ID graph. The code layer is a Graphify-style AST pass over the product source. The bridge is the traceability protocol turned into extracted edges — it is the entire reason this is more than "run `/graphify` on the repo."
+
+---
+
+## 2. Top-level shape
+
+`status/devgraph.json` follows the **NetworkX node-link format** (`nx.node_link_data`), the same lineage Graphify uses — so force-graph viz tooling consumes it directly — plus three PRD-CE extensions (`conformance`, `coverage`, and a populated `graph` block).
+
+```json
+{
+  "directed": true,
+  "multigraph": false,
+  "schema_version": "0.1",
+  "graph": { /* §6 metadata: scope, generators, readiness cross-link, counts */ },
+  "nodes": [ /* §3 */ ],
+  "links": [ /* §4 — node-link calls edges "links" */ ],
+  "conformance": [ /* §5 — ARC- rule verdicts */ ],
+  "coverage": { /* §7 — graph-wide build/verify/conformance rollup */ },
+  "hyperedges": [ /* §8 — optional, Graphify parity */ ]
+}
+```
+
+`links` is the NetworkX node-link key for edges; a producer that emits `edges` instead must alias it. The readiness consumer (§9) reads only `nodes[].status` and `conformance[]`, never walks `links` — keeping the scorecard decoupled from edge representation.
+
+---
+
+## 3. Node schema
+
+```json
+{
+  "id": "engine_parser_parsesotentry",
+  "label": "parseSoTEntry",
+  "layer": "code",
+  "node_kind": "function",
+  "file_type": "code",
+  "source_file": "packages/extension/engine/parser/parse.ts",
+  "source_location": "L42",
+  "status": "traced",
+  "implements": ["API-002", "BR-001"],
+  "community": 3,
+  "rationale": null,
+  "confidence": "EXTRACTED"
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | ✓ | Stable identifier. **Spec nodes**: the ID itself (`API-002`). **Code nodes**: Graphify convention `{parent_dir}_{file}_{symbol}`, lowercased, `[a-z0-9_]` only. |
+| `label` | ✓ | Human-readable name. |
+| `layer` | ✓ | `spec` or `code`. Drives which status enum applies and which readiness dimension reads it. |
+| `node_kind` | ✓ | Within `code`: one of `code_node_types` in the domain profile (`module`/`class`/`function`/`table`/`endpoint`). Within `spec`: the ID prefix (`BR`, `API`, `ARC`…). |
+| `file_type` | ✓ | Graphify-compat render hint: `code`, `document`, `concept`. |
+| `source_file` | ✓ | Repo-relative path the node was extracted from. |
+| `source_location` | – | Line anchor (`L42`) for click-through. |
+| `status` | ✓ | The **pulse** — see §3.1. Pre-computed by the extractor from edges so consumers don't re-derive it. |
+| `implements` | – | Code nodes only: denormalized list of spec IDs this node bridges to (mirrors its outbound `implements`/`verifies` edges). Convenience for viz tooltips and readiness. |
+| `community` | – | Leiden community index (Graphify-style clustering). Lets HeartBeat color emergent subsystems. |
+| `rationale` | – | Graphify pattern: design intent / "why" stored as a node **attribute**, not a separate node. |
+| `confidence` | – | For inferred nodes: `EXTRACTED` / `INFERRED` / `AMBIGUOUS` (§10). AST-extracted code nodes are always `EXTRACTED`. |
+
+### 3.1 The `status` enum — the pulse
+
+`status` is what HeartBeat colors. It is derived by the extractor from the bridge edges, so it is the single field that encodes build-vs-blueprint per node.
+
+**Spec-layer node status:**
+
+| `status` | Means | Bridge condition | HeartBeat |
+|---|---|---|---|
+| `implemented` | Built and verified | ≥1 `implements` **and** ≥1 `verifies` inbound edge | 🟢 green |
+| `implemented_unverified` | Built, no test | ≥1 `implements`, 0 `verifies` | 🟡 amber |
+| `unimplemented` | Specified, no code | 0 `implements` inbound | 🔴 red |
+
+**Code-layer node status:**
+
+| `status` | Means | Bridge condition | HeartBeat |
+|---|---|---|---|
+| `traced` | Implements ≥1 spec | ≥1 outbound `implements`/`verifies`/`references` | 🟢 green |
+| `orphan` | Code with no spec ("context leak") | 0 outbound bridge edges | ⚪ grey |
+| `drift` | Breaks an architecture rule | ≥1 outbound `violates` edge | 🔴 red |
+
+`unimplemented` specs and `drift` code are the two red states — the failures the heartbeat exists to surface.
+
+---
+
+## 4. Edge (`links`) schema
+
+```json
+{
+  "source": "engine_parser_parsesotentry",
+  "target": "API-002",
+  "relation": "implements",
+  "confidence": "EXTRACTED",
+  "confidence_score": 1.0,
+  "source_location": "packages/extension/engine/parser/parse.ts:40"
+}
+```
+
+Relations, grouped by which layers they connect:
+
+| `relation` | From → To | Source | Confidence |
+|---|---|---|---|
+| `calls` | code → code | AST call graph | `EXTRACTED` / `INFERRED` |
+| `imports` | code → code | AST import statement | `EXTRACTED` |
+| `implements` | code → spec | `// @implements <ID>` tag | `EXTRACTED` (tag) / `INFERRED` (name match) |
+| `verifies` | code(test) → spec | `// @verifies <ID>` or a `TEST-` entry referencing the ID | `EXTRACTED` / `INFERRED` |
+| `references` | code → spec | `// @see <ID>` tag | `EXTRACTED` |
+| `violates` | code → spec(ARC) | conformance diff (§5) | `EXTRACTED` (structural check) |
+| `relates_to` | spec → spec | ID cross-reference in SoT body | `EXTRACTED` |
+
+`calls` edges must stay within one language and point caller → callee (Graphify rule). Bridge edges always point **code → spec**, never the reverse.
+
+---
+
+## 5. `conformance` block — architecture rules as checkable claims
+
+`ARC-` decisions often make *structural claims* the code graph can verify (e.g. *"the `engine/` layer must have zero VS Code imports"*). Each such claim becomes a conformance entry with a machine verdict — this is the drift signal that feeds the `architecture_conformance` readiness dimension.
+
+```json
+{
+  "arc_id": "ARC-004",
+  "rule": "engine/ layer must not import the vscode API",
+  "check": { "type": "forbidden_import", "scope": "packages/extension/engine/**", "forbidden": "vscode" },
+  "verdict": "violate",
+  "violations": [
+    { "source": "engine_parser_parsesotentry", "target": "vscode", "source_location": "parser.ts:12" }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `arc_id` | ✓ | The `ARC-` (or `BR-`) ID whose claim is being checked. Must match a spec node `id`. |
+| `rule` | ✓ | Human-readable statement of the constraint. |
+| `check` | – | Machine description of how it was evaluated (advisory; for reproducibility). |
+| `verdict` | ✓ | `pass` (holds), `violate` (broken — drift), `unknown` (could not be checked). |
+| `violations` | – | When `violate`: the offending edges, for HeartBeat to highlight and readiness to cite. |
+
+A `violate` produces a `violates` bridge edge from each offending code node to the ARC spec node, flipping that code node's `status` to `drift`.
+
+---
+
+## 6. `graph` metadata block
+
+```json
+{
+  "scope": "EPIC-06",
+  "scope_ids": ["BR-001", "API-002", "ARC-004", "..."],
+  "generated_by": "prd-v07-build-graph@0.1",
+  "generated_at": "2026-06-06T18:04:11Z",
+  "readiness_ref": "status/readiness.json",
+  "source_root": "packages/extension",
+  "languages": ["typescript"],
+  "layer_counts": { "spec": 40, "code": 214 },
+  "edge_counts": { "implements": 31, "verifies": 22, "calls": 180, "violates": 1 }
+}
+```
+
+`scope` ties the graph to an EPIC (or `"repo"` for a full-repo build). `scope_ids` is the spec set the EPIC claims — the denominator for coverage. `readiness_ref` cross-links to the scorecard so the two outputs are navigable as a pair. Timestamps are stamped by the producer (the scorer never invents them).
+
+---
+
+## 7. `coverage` rollup
+
+A graph-wide summary HeartBeat shows as headline gauges and readiness can sanity-check against.
+
+```json
+{
+  "specs_total": 40,
+  "specs_implemented": 31,
+  "specs_unverified": 5,
+  "specs_unimplemented": 4,
+  "code_total": 214,
+  "code_orphan": 8,
+  "conformance_rules": 6,
+  "conformance_passing": 5,
+  "by_prefix": {
+    "BR":  { "total": 12, "implemented": 11 },
+    "API": { "total": 10, "implemented": 9 },
+    "DBT": { "total": 6,  "implemented": 6 }
+  }
+}
+```
+
+`by_prefix` is graph-global; the readiness EPIC dimension recomputes coverage scoped to one EPIC's `scope_ids`, so the two can differ — that is expected, not a conflict.
+
+---
+
+## 8. `hyperedges` (optional, Graphify parity)
+
+Group relationships connecting 3+ nodes that pairwise edges miss — e.g. *all* functions in an auth flow, or *all* code implementing one `FEA-`. Use sparingly.
+
+```json
+{ "id": "auth_flow", "label": "Authentication flow", "nodes": ["...", "...", "..."], "relation": "participate_in", "confidence": "INFERRED", "confidence_score": 0.85 }
+```
+
+---
+
+## 9. How readiness consumes this graph
+
+`scripts/_readiness/epic.py` reads `status/devgraph.json` via `load_devgraph()` and powers two EPIC dimensions (both **auto-disable** when the file is absent, so pre-build repos score unchanged):
+
+| Readiness dimension | Reads | Score |
+|---|---|---|
+| `implementation_coverage` | `nodes[].status` for `layer:spec` nodes whose `id` is in the EPIC's Section 3 **and** of an implementable prefix (`BR/API/DBT/ENT/FEA/SCR/UJ`) | fraction with status `implemented` or `implemented_unverified` |
+| `architecture_conformance` | `conformance[]` entries whose `arc_id` is referenced by the EPIC | fraction with `verdict: pass` |
+
+Plus a critical cap: **`unbuilt_specs`** caps an EPIC at 60 when `implementation_coverage < 50%` — most of what the EPIC claims to build has no implementing code. See [`READINESS_PROTOCOL.md` §4, §7](READINESS_PROTOCOL.md).
+
+The contract that matters for readiness: spec nodes carry an accurate `status`, and conformance entries carry an `arc_id` + `verdict`. Everything else is for HeartBeat.
+
+---
+
+## 10. Confidence audit trail (borrowed from Graphify)
+
+Every inferred node and edge carries an honest confidence label, so HeartBeat can visually distinguish *known* structure from *guessed* structure and readiness can discount the latter.
+
+| Label | `confidence_score` | When |
+|---|---|---|
+| `EXTRACTED` | `1.0` | Explicit in source — an `@implements` tag, an import statement, a structural conformance check. |
+| `INFERRED` | discrete `0.55`–`0.95` | A reasonable deduction — a function name matching a `BR-` keyword, a likely call target. Use the Graphify discrete rubric, never `0.5`. |
+| `AMBIGUOUS` | `0.1`–`0.3` | Uncertain — surfaced for human review, never silently dropped. |
+
+A bridge edge from a literal `@implements BR-101` tag is `EXTRACTED`. A guess that `validateToken()` implements `BR-101` because the names align is `INFERRED`. This is what keeps the graph trustworthy: the green pulse means *traced*, not *assumed*.
+
+---
+
+## 11. Producing the graph (the pipeline)
+
+Generation is the job of the v0.7 build skill (`prd-v07-build-graph`, forthcoming) and is intentionally **not** part of the readiness scorer — the scorer only reads the output. The pipeline mirrors Graphify's stages, scoped to the active EPIC:
+
+```
+detect()  →  extract_ast()  →  harvest_tags()  →  check_conformance()  →  derive_status()  →  build_node_link()  →  write devgraph.json
+            (tree-sitter,      (@implements/      (ARC- rules vs         (per §3.1)            (+ Leiden cluster,
+             free, no LLM)      @verifies/@see)    code edges)                                  god nodes)
+```
+
+- **`extract_ast`** — Graphify Pass 1: classes, functions, imports, call graph, SQL tables/FKs. Deterministic, free, cacheable by content hash for incremental rebuilds.
+- **`harvest_tags`** — scan code comments for `@implements`/`@verifies`/`@see <ID>`; emit bridge edges (`EXTRACTED`). Optionally infer additional bridges by name/context match (`INFERRED`).
+- **`check_conformance`** — evaluate each `ARC-` rule against the code edges; emit `conformance[]` verdicts and `violates` edges.
+- **`derive_status`** — set every node's `status` per §3.1 from its bridge edges.
+- **`build_node_link`** — assemble the node-link JSON, run Leiden clustering for `community`, compute god nodes, write `status/devgraph.json`.
+
+Until that skill lands, the schema here is the stable target: HeartBeat can develop against the §12 example, and the readiness dimensions already read the contract.
+
+---
+
+## 12. Worked example
+
+A minimal but complete `status/devgraph.json` — one implemented spec, one unbuilt spec, one drift, one conformance violation:
+
+```json
+{
+  "directed": true,
+  "multigraph": false,
+  "schema_version": "0.1",
+  "graph": {
+    "scope": "EPIC-01",
+    "scope_ids": ["BR-001", "API-002", "ARC-004"],
+    "generated_by": "prd-v07-build-graph@0.1",
+    "generated_at": "2026-06-06T18:04:11Z",
+    "readiness_ref": "status/readiness.json",
+    "layer_counts": { "spec": 3, "code": 2 }
+  },
+  "nodes": [
+    { "id": "BR-001",  "label": "Free tier rate limit", "layer": "spec", "node_kind": "BR",  "file_type": "concept", "source_file": "SoT/SoT.BUSINESS_RULES.md", "status": "implemented" },
+    { "id": "API-002", "label": "POST /parse",          "layer": "spec", "node_kind": "API", "file_type": "concept", "source_file": "SoT/SoT.API_CONTRACTS.md", "status": "unimplemented" },
+    { "id": "ARC-004", "label": "engine has no vscode import", "layer": "spec", "node_kind": "ARC", "file_type": "concept", "source_file": "SoT/SoT.TECHNICAL_DECISIONS.md", "status": "implemented" },
+    { "id": "limiter_ratelimiter_check", "label": "RateLimiter.check", "layer": "code", "node_kind": "function", "file_type": "code", "source_file": "src/limiter.ts", "source_location": "L20", "status": "traced", "implements": ["BR-001"], "confidence": "EXTRACTED" },
+    { "id": "engine_parser_parse", "label": "parse", "layer": "code", "node_kind": "function", "file_type": "code", "source_file": "engine/parser.ts", "source_location": "L12", "status": "drift", "confidence": "EXTRACTED" }
+  ],
+  "links": [
+    { "source": "limiter_ratelimiter_check", "target": "BR-001", "relation": "implements", "confidence": "EXTRACTED", "confidence_score": 1.0, "source_location": "src/limiter.ts:18" },
+    { "source": "engine_parser_parse", "target": "ARC-004", "relation": "violates", "confidence": "EXTRACTED", "confidence_score": 1.0, "source_location": "engine/parser.ts:12" }
+  ],
+  "conformance": [
+    { "arc_id": "ARC-004", "rule": "engine/ must not import vscode",
+      "check": { "type": "forbidden_import", "scope": "engine/**", "forbidden": "vscode" },
+      "verdict": "violate",
+      "violations": [ { "source": "engine_parser_parse", "target": "vscode", "source_location": "engine/parser.ts:12" } ] }
+  ],
+  "coverage": {
+    "specs_total": 3, "specs_implemented": 2, "specs_unimplemented": 1,
+    "code_total": 2, "code_orphan": 0,
+    "conformance_rules": 1, "conformance_passing": 0
+  }
+}
+```
+
+Reading the pulse: `BR-001` 🟢 (built + verified), `API-002` 🔴 (specified, never built), `ARC-004` flagged by a `violate` so `engine_parser_parse` is 🔴 drift. That is exactly what HeartBeat renders and what `implementation_coverage` (1 of 2 implementable specs = 50%) and `architecture_conformance` (0 of 1 ARC rule passing = 0%) score.
+
+---
+
+## 13. Versioning
+
+`schema_version` bumps on any breaking shape change. The Development Graph schema versions **independently** of `readiness.json`'s `schema_version` — they are separate contracts that cross-link via `graph.readiness_ref`. HeartBeat should pin the `schema_version` it supports and warn on mismatch.
+
+| Version | Date | Change |
+|---|---|---|
+| 0.1 | 2026-06-06 | Initial draft: three-layer node-link schema, status pulse, conformance block, readiness consumption, HeartBeat contract. |

--- a/docs/READINESS_PROTOCOL.md
+++ b/docs/READINESS_PROTOCOL.md
@@ -194,6 +194,10 @@ Each dimension scores 0–100. Dimensions that can't be evaluated (e.g. no Confi
 | `confidence_avg` | 0.15 | Mean confidence of referenced IDs (scaled to 0–100). Auto-disabled if no Confidence fields found. |
 | `status_maturity` | 0.05 | Percentage of resolved IDs with `Status ≠ Draft`. Auto-disabled if no Status fields found. |
 | `file_readiness` | 0.05 | Percentage of SoT files the EPIC depends on that contain real entries (not placeholders). Catches `SoT.USER_JOURNEYS.md: *Pending PRD development*` cases. |
+| `implementation_coverage` | 0.10 | **(Development Graph, v0.6→v0.7)** Of the EPIC's buildable specs (prefixes `BR/API/DBT/ENT/FEA/SCR/UJ` in Section 3), the fraction with implementing code — a spec node in `status/devgraph.json` whose `status` is `implemented`/`implemented_unverified`. The build-vs-blueprint signal. Auto-disabled when no dev graph exists. |
+| `architecture_conformance` | 0.05 | **(Development Graph, v0.6→v0.7)** Of the `ARC-` rules referenced by the EPIC, the fraction whose conformance `verdict` is `pass` in the dev graph. Catches code that has drifted from a recorded architecture decision. Auto-disabled when no dev graph exists or the EPIC touches no checked `ARC-` rule. |
+
+> **Development Graph dimensions** read `status/devgraph.json` — see [`DEVELOPMENT_GRAPH.md`](DEVELOPMENT_GRAPH.md) for the schema (the HeartBeat data contract). They are **additive** to the nine spec-phase dimensions: raw weights are relative and renormalized at runtime (§8), so adding two dormant dimensions changes **no** score for a repo that has not yet built anything. They activate only once a v0.7 build produces a dev graph.
 
 ### Stage dimensions
 
@@ -288,6 +292,7 @@ final_score    = min(cap, max(0, weighted_score − penalty))
 | `test_coverage_zero` | 55 | `test_coverage_declared == 0` and EPIC references any API-/BR-. |
 | `spec_resolution_low` | 60 | `spec_resolution < 80%` — too many dangling IDs. |
 | `stub_sot_file` | 60 | Any SoT file the EPIC depends on is a placeholder stub. |
+| `unbuilt_specs` | 60 | `implementation_coverage < 50%` — most scoped specs have no implementing code. Only fires once a dev graph exists (dormant pre-build). Cites the SoT file owning the most unbuilt specs. |
 
 **Critical caps** (Stage):
 

--- a/scripts/_readiness/common.py
+++ b/scripts/_readiness/common.py
@@ -6,6 +6,7 @@ three modules can stay focused on their own scoring logic.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,6 +42,16 @@ STUB_KEYWORDS = (
 
 SEVERITY_PENALTY = {"high": 10, "medium": 3, "low": 1}
 MAX_PENALTY = 25
+
+
+# ---------- Development Graph (v0.6→v0.7) constants ---------- #
+
+# Spec prefixes that the codebase is expected to IMPLEMENT — i.e. a code node
+# should carry an `@implements` bridge edge back to them. Used by the EPIC
+# `implementation_coverage` dimension to compute build-vs-blueprint. Spec types
+# that code does not implement (RISK, CFD, KPI, GTM, TECH decisions, LL) are
+# excluded so coverage is not diluted by non-buildable specs.
+IMPLEMENTABLE_PREFIXES = {"BR", "API", "DBT", "ENT", "FEA", "SCR", "UJ"}
 
 
 # ---------- SoT entry ---------- #
@@ -129,6 +140,53 @@ def load_readiness_config(repo: Path) -> dict:
         return {}
     with path.open() as f:
         return yaml.safe_load(f) or {}
+
+
+def load_devgraph(repo: Path) -> Optional[dict]:
+    """Load the Development Graph (`status/devgraph.json`) if it exists.
+
+    The dev graph is the "as-built" layer: code nodes extracted from the product
+    codebase, bridged to spec IDs via @implements/@verifies edges. It is produced
+    during v0.7 build execution (see docs/DEVELOPMENT_GRAPH.md). Returns ``None``
+    when absent or unparseable — every dev-graph readiness dimension treats
+    ``None`` as "not applicable" and auto-disables, so repos that have not yet
+    built anything (or the methodology repo itself) score exactly as before.
+    """
+    path = repo / "status" / "devgraph.json"
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(errors="replace"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def devgraph_spec_status(devgraph: Optional[dict]) -> dict[str, str]:
+    """Index spec-layer nodes by ID → coverage status from the dev graph.
+
+    Status values (set by the extractor, see docs/DEVELOPMENT_GRAPH.md):
+      ``implemented``            — ≥1 inbound `implements` edge
+      ``implemented_unverified`` — implemented but no `verifies` edge
+      ``unimplemented``          — spec node with no `implements` edge
+    """
+    out: dict[str, str] = {}
+    if not devgraph:
+        return out
+    for node in devgraph.get("nodes", []) or []:
+        if node.get("layer") == "spec" and node.get("id"):
+            out[node["id"]] = node.get("status", "unimplemented")
+    return out
+
+
+def devgraph_conformance(devgraph: Optional[dict]) -> list[dict]:
+    """Return the architecture-conformance verdicts carried by the dev graph.
+
+    Each entry: ``{arc_id, rule, verdict: pass|violate|unknown, violations[]}``.
+    """
+    if not devgraph:
+        return []
+    return devgraph.get("conformance", []) or []
 
 
 # ---------- Repo discovery ---------- #

--- a/scripts/_readiness/epic.py
+++ b/scripts/_readiness/epic.py
@@ -22,30 +22,43 @@ from . import SCHEMA_VERSION, VERSION
 from .common import (
     HEADING_DEF_RE,
     ID_RE,
+    IMPLEMENTABLE_PREFIXES,
     SEVERITY_PENALTY,
     MAX_PENALTY,
     SoTEntry,
     build_summary,
+    devgraph_conformance,
+    devgraph_spec_status,
     expand_ranges,
     extract_section,
     find_repo_root,
     index_all_entries,
+    load_devgraph,
     load_domain_profile,
     load_readiness_config,
     parse_frontmatter,
 )
 
 
+# Raw weights are RELATIVE — renormalize_weights() rescales the active set to
+# sum to 1.0 at runtime, so disabled / not_applicable dimensions never distort
+# the result. The first nine are the spec-phase dimensions (sum 1.00). The two
+# Development-Graph dimensions are ADDITIVE v0.7 build-phase signals: they stay
+# dormant (score None → not_applicable) until a status/devgraph.json exists, so
+# adding them changes NO score for repos that have not yet built anything.
 EPIC_WEIGHTS = {
-    "spec_resolution":        0.20,
-    "spec_depth":             0.15,
-    "test_coverage_declared": 0.15,
-    "upstream_gate":          0.10,
-    "dependency_readiness":   0.10,
-    "ambiguity_load":         0.05,
-    "confidence_avg":         0.15,
-    "status_maturity":        0.05,
-    "file_readiness":         0.05,
+    "spec_resolution":          0.20,
+    "spec_depth":               0.15,
+    "test_coverage_declared":   0.15,
+    "upstream_gate":            0.10,
+    "dependency_readiness":     0.10,
+    "ambiguity_load":           0.05,
+    "confidence_avg":           0.15,
+    "status_maturity":          0.05,
+    "file_readiness":           0.05,
+    # --- Development Graph (v0.6→v0.7), dormant until status/devgraph.json exists ---
+    "implementation_coverage":  0.10,
+    "architecture_conformance": 0.05,
 }
 
 # Critical caps: (rule_name, cap_value, reason). Evaluated top-to-bottom; lowest cap wins.
@@ -56,6 +69,8 @@ CRITICAL_CAPS = [
      "spec_resolution below 80% — too many referenced IDs don't resolve."),
     ("stub_sot_file", 60,
      "A SoT file referenced by this EPIC is a placeholder stub."),
+    ("unbuilt_specs", 60,
+     "implementation_coverage below 50% — most scoped specs have no implementing code."),
 ]
 
 
@@ -346,6 +361,92 @@ def compute_file_readiness(ctx: EpicContext, index: dict[str, SoTEntry],
     return score, unmet
 
 
+# ---------- Development Graph dimensions (v0.6→v0.7) ---------- #
+
+def compute_implementation_coverage(
+    ctx: EpicContext, devgraph: Optional[dict], domain: dict, sot_scores: dict,
+) -> tuple[Optional[float], list[dict]]:
+    """Of the EPIC's buildable specs, how many have implementing code?
+
+    Reads the Development Graph's spec-layer node status (see
+    docs/DEVELOPMENT_GRAPH.md). A spec is "covered" when it carries ≥1 inbound
+    `implements` edge — i.e. some code unit declared `@implements <ID>`. This is
+    the build-vs-blueprint signal: a fully specified EPIC whose specs have no
+    implementing code is not actually built. Auto-disables (returns ``None``)
+    when no dev graph exists or the EPIC references no buildable spec, so the
+    dimension is dormant before v0.7 build execution.
+    """
+    if devgraph is None:
+        return None, []
+    scoped = [i for i in ctx.referenced_ids if i.split("-")[0] in IMPLEMENTABLE_PREFIXES]
+    if not scoped:
+        return None, []
+    status = devgraph_spec_status(devgraph)
+    covered_states = {"implemented", "implemented_unverified"}
+    covered = sum(1 for i in scoped if status.get(i) in covered_states)
+    score = (covered / len(scoped)) * 100.0
+    unmet: list[dict] = []
+    for i in scoped:
+        if status.get(i) in covered_states:
+            continue
+        prefix = i.split("-")[0]
+        owning = (domain.get(prefix) or {}).get("file")
+        state = status.get(i, "absent from dev graph")
+        entry = {
+            "dimension": "implementation_coverage", "ref": i,
+            "reason": f"{i} is in EPIC scope but no code node @implements it (status: {state}).",
+            "severity": "high",
+            "fix": f"Implement {i} and tag the code unit `// @implements {i}`, then rebuild the dev graph.",
+        }
+        if owning:
+            entry["caused_by"] = owning
+            entry["caused_by_score"] = sot_scores.get(owning, {}).get("score")
+        unmet.append(entry)
+    return score, unmet
+
+
+def compute_architecture_conformance(
+    ctx: EpicContext, devgraph: Optional[dict],
+) -> tuple[Optional[float], list[dict]]:
+    """Do the ARC- rules this EPIC touches hold in the as-built code?
+
+    Reads conformance verdicts from the dev graph, scoped to ARC- IDs referenced
+    in Section 3. Each rule is ``pass`` / ``violate`` / ``unknown``; the score is
+    the fraction passing. A `violate` is high-severity drift (the code
+    contradicts a recorded architecture decision); `unknown` is medium (the rule
+    could not be checked). Auto-disables when no dev graph exists or the EPIC
+    touches no ARC- rule with a verdict.
+    """
+    if devgraph is None:
+        return None, []
+    scoped_arc = {i for i in ctx.referenced_ids if i.split("-")[0] == "ARC"}
+    if not scoped_arc:
+        return None, []
+    rules = [c for c in devgraph_conformance(devgraph) if c.get("arc_id") in scoped_arc]
+    if not rules:
+        return None, []
+    passing = sum(1 for c in rules if c.get("verdict") == "pass")
+    score = (passing / len(rules)) * 100.0
+    unmet: list[dict] = []
+    for c in rules:
+        verdict = c.get("verdict", "unknown")
+        if verdict == "pass":
+            continue
+        viols = c.get("violations") or []
+        where = ""
+        if viols:
+            v0 = viols[0]
+            where = f" e.g. {v0.get('source')} → {v0.get('target')} ({v0.get('source_location', '?')})"
+        unmet.append({
+            "dimension": "architecture_conformance", "ref": c.get("arc_id"),
+            "reason": f"{c.get('arc_id')} rule \"{c.get('rule', '')}\" is {verdict} in the as-built code.{where}",
+            "severity": "high" if verdict == "violate" else "medium",
+            "caused_by": "SoT/SoT.TECHNICAL_DECISIONS.md",
+            "fix": f"Resolve the drift so the code satisfies {c.get('arc_id')}, or revise the rule.",
+        })
+    return score, unmet
+
+
 # ---------- Aggregation ---------- #
 
 def apply_overrides(ctx: EpicContext, readiness_config: dict) -> dict:
@@ -375,6 +476,7 @@ def compute(epic_file: Path, repo: Path, inputs_override: Optional[dict]) -> dic
     domain = load_domain_profile(repo)
     config = load_readiness_config(repo)
     index = index_all_entries(repo)
+    devgraph = load_devgraph(repo)  # None until v0.7 build produces status/devgraph.json
     ctx = parse_epic(epic_file, inputs_override)
 
     existing: Optional[dict] = None
@@ -423,6 +525,14 @@ def compute(epic_file: Path, repo: Path, inputs_override: Optional[dict]) -> dic
 
     s, u = compute_file_readiness(ctx, index, repo, domain, sot_scores)
     dims["file_readiness"] = {"score": round(s, 1)}
+    unmet.extend(u)
+
+    cov_score, u = compute_implementation_coverage(ctx, devgraph, domain, sot_scores)
+    dims["implementation_coverage"] = {"score": round(cov_score, 1) if cov_score is not None else None}
+    unmet.extend(u)
+
+    conf_score, u = compute_architecture_conformance(ctx, devgraph)
+    dims["architecture_conformance"] = {"score": round(conf_score, 1) if conf_score is not None else None}
     unmet.extend(u)
 
     override_state = apply_overrides(ctx, config)
@@ -475,6 +585,20 @@ def compute(epic_file: Path, repo: Path, inputs_override: Optional[dict]) -> dic
                              "reason": CRITICAL_CAPS[2][2],
                              "caused_by": stub_files[0] if stub_files else None,
                              "caused_by_score": sot_scores.get(stub_files[0], {}).get("score") if stub_files else None})
+    # Dev-graph cap: only fires once a graph exists (score is not None) and most
+    # scoped specs are unbuilt. Dormant for pre-build repos.
+    impl_cov = score_map.get("implementation_coverage")
+    if impl_cov is not None and impl_cov < 50:
+        cap_score = min(cap_score, CRITICAL_CAPS[3][1])
+        uncovered_files: dict[str, int] = {}
+        for c in unmet:
+            if c.get("dimension") == "implementation_coverage" and c.get("caused_by"):
+                uncovered_files[c["caused_by"]] = uncovered_files.get(c["caused_by"], 0) + 1
+        worst = max(uncovered_files.items(), key=lambda x: x[1]) if uncovered_files else (None, 0)
+        caps_applied.append({"rule": "unbuilt_specs", "cap": CRITICAL_CAPS[3][1],
+                             "reason": CRITICAL_CAPS[3][2],
+                             "caused_by": worst[0],
+                             "caused_by_score": sot_scores.get(worst[0], {}).get("score") if worst[0] else None})
 
     penalized = max(0.0, weighted_score - penalty)
     final_score = min(cap_score, penalized)

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -143,6 +143,109 @@ def test_dimension_override_disabled(healthy_repo: Path) -> None:
         f"weights sum to {active_weights}, expected ~1.0 after renormalization"
 
 
+# ---------- Development Graph dimensions (v0.6→v0.7) ---------- #
+
+# Implementable specs referenced by the healthy_repo EPIC-01 Section 3.
+HEALTHY_IMPLEMENTABLE = [
+    "BR-001", "BR-002", "BR-003",
+    "API-001", "API-002", "API-003",
+    "DBT-001", "DBT-002", "UJ-001",
+]
+
+
+def write_devgraph(repo: Path, spec_status: dict[str, str],
+                   conformance: list[dict] | None = None) -> None:
+    """Write a contract-shaped status/devgraph.json (see docs/DEVELOPMENT_GRAPH.md)."""
+    nodes = [
+        {"id": sid, "label": sid, "layer": "spec", "node_kind": sid.split("-")[0],
+         "file_type": "concept", "source_file": "SoT/x.md", "status": status}
+        for sid, status in spec_status.items()
+    ]
+    devgraph = {
+        "directed": True, "multigraph": False, "schema_version": "0.1",
+        "graph": {"scope": "EPIC-01", "scope_ids": list(spec_status),
+                  "generated_by": "test", "readiness_ref": "status/readiness.json"},
+        "nodes": nodes,
+        "links": [],
+        "conformance": conformance or [],
+    }
+    out = repo / "status" / "devgraph.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(devgraph))
+
+
+def test_devgraph_absent_dimensions_dormant(healthy_repo: Path) -> None:
+    """With no status/devgraph.json, both dev-graph dimensions auto-disable —
+    they must NOT distort the score (the whole point of the dormant design)."""
+    _, data = run_readiness(healthy_repo)
+    dims = next(iter(data["epics"].values()))["dimensions"]
+    assert dims["implementation_coverage"].get("status") == "not_applicable"
+    assert dims["architecture_conformance"].get("status") == "not_applicable"
+    # Dormant dimensions carry no weight.
+    assert "weight" not in dims["implementation_coverage"]
+    assert "weight" not in dims["architecture_conformance"]
+
+
+def test_implementation_coverage_activates_when_built(healthy_repo: Path) -> None:
+    """A dev graph marking every scoped spec implemented → coverage 100, active."""
+    write_devgraph(healthy_repo, {sid: "implemented" for sid in HEALTHY_IMPLEMENTABLE})
+    _, data = run_readiness(healthy_repo)
+    dim = next(iter(data["epics"].values()))["dimensions"]["implementation_coverage"]
+    assert dim.get("score") == 100.0, dim
+    assert dim.get("weight", 0) > 0, "active dimension should carry renormalized weight"
+
+
+def test_unbuilt_specs_triggers_cap(healthy_repo: Path) -> None:
+    """Most scoped specs unbuilt → implementation_coverage < 50 → unbuilt_specs cap,
+    with each unbuilt spec surfaced as an unmet criterion citing its owning file."""
+    status = {sid: "unimplemented" for sid in HEALTHY_IMPLEMENTABLE}
+    status["BR-001"] = "implemented"
+    status["API-001"] = "implemented"  # 2 / 9 built ≈ 22% < 50
+    write_devgraph(healthy_repo, status)
+
+    _, data = run_readiness(healthy_repo)
+    epic_block = next(iter(data["epics"].values()))
+
+    cap_rules = [c["rule"] for c in epic_block["caps"]]
+    assert "unbuilt_specs" in cap_rules, f"expected unbuilt_specs cap; got {cap_rules}"
+    cap = next(c for c in epic_block["caps"] if c["rule"] == "unbuilt_specs")
+    assert cap["cap"] == 60
+    assert cap["caused_by"], "cap should cite the SoT file owning the most unbuilt specs"
+    assert epic_block["score"] <= 60, "cap must bound the final score"
+
+    unmet = [c for c in epic_block["unmet_criteria"]
+             if c["dimension"] == "implementation_coverage"]
+    refs = {c.get("ref") for c in unmet}
+    assert "DBT-001" in refs and "BR-002" in refs, f"unbuilt specs not surfaced: {refs}"
+    # Each unmet cites the owning SoT file (graph traversability).
+    br_unmet = next(c for c in unmet if c.get("ref") == "BR-002")
+    assert br_unmet.get("caused_by") == "SoT/SoT.BUSINESS_RULES.md"
+
+
+def test_architecture_conformance_violation(healthy_repo: Path) -> None:
+    """An ARC-001 conformance violation → architecture_conformance scores 0 and
+    surfaces a drift unmet criterion citing the technical-decisions SoT file."""
+    conformance = [{
+        "arc_id": "ARC-001", "rule": "three-tier boundary must hold",
+        "verdict": "violate",
+        "violations": [{"source": "ui_widget_render", "target": "db_pool",
+                        "source_location": "ui/widget.ts:9"}],
+    }]
+    write_devgraph(healthy_repo,
+                   {sid: "implemented" for sid in HEALTHY_IMPLEMENTABLE},
+                   conformance=conformance)
+
+    _, data = run_readiness(healthy_repo)
+    epic_block = next(iter(data["epics"].values()))
+    dim = epic_block["dimensions"]["architecture_conformance"]
+    assert dim.get("score") == 0.0, dim
+
+    drift = [c for c in epic_block["unmet_criteria"]
+             if c["dimension"] == "architecture_conformance"]
+    assert any(c.get("ref") == "ARC-001" for c in drift), drift
+    assert drift[0].get("caused_by") == "SoT/SoT.TECHNICAL_DECISIONS.md"
+
+
 # ---------- Summary block ---------- #
 
 def test_summary_top_blockers_ranking(empty_repo: Path) -> None:


### PR DESCRIPTION
## Summary

Introduces the **Development Graph** — the "as-built" layer of the PRD-CE knowledge graph. Where the ID graph (`BR-`, `UJ-`, `ARC-`…) is top-down intent authored before code exists, the Development Graph is bottom-up structure extracted from the product codebase during v0.7, **bridged back to spec IDs via the `@implements` tags rule 04 already mandates**. That bridge lets readiness measure *build-vs-blueprint* in v0.6/v0.7 — which specs have code, which code has no spec, and where code has drifted from a recorded `ARC-` decision.

Inspired by [Graphify](https://github.com/safishamsi/graphify). The output, `status/devgraph.json`, is the **data contract** the private HeartBeat visualizer renders as a live pulse (built / unbuilt / drifted).

## Why

Today every readiness dimension is spec-side. There's no signal for "is the thing actually built, and does it still match the architecture?" The methodology already mandates `@implements` traceability and a "no orphan code" rule — this PR turns those latent comments into extracted graph edges and makes them *measurable*.

## What's in this PR

**Scorer (additive + dormant — see Safety):**
- `domain-profile.yaml` — `code_node_types` + `bridge_relations` taxonomy
- `scripts/_readiness/common.py` — `load_devgraph()`, `IMPLEMENTABLE_PREFIXES`, accessors
- `scripts/_readiness/epic.py` — two EPIC dimensions (`implementation_coverage`, `architecture_conformance`) + an `unbuilt_specs` critical cap
- `tests/test_readiness.py` — 4 new cases (dormant-by-default, coverage activation, cap trigger, drift)

**Contract:**
- `docs/DEVELOPMENT_GRAPH.md` (new) — three-layer node-link schema, the `status` pulse, conformance block, readiness consumption, and the HeartBeat contract
- `docs/READINESS_PROTOCOL.md` — §4 dimension rows + §7 cap

**Embedded across the methodology (the point — not a bolt-on):**
- `README.md` — code layer in Readiness Scoring + v0.6/v0.7 lifecycle DoD
- `PRD.md` — v0.6 *expected topology* / conformance rules; v0.7 *as-built* graph + DoD line
- `.claude/rules/04-coding-standards.md` — `@implements` → bridge edges; `.claude/rules/07-readiness-protocol.md` — the new dimensions
- `SoT/SoT.TECHNICAL_DECISIONS.md` — a **Conformance Rule** field on the ARC template; `SoT/SoT.README.md` — as-built layer note
- skills `prd-v06-architecture-design` + `prd-v07-implementation-loop` — conformance authoring, dev-graph output, coverage quality gate, HeartBeat downstream

## Safety / non-breaking

The two new dimensions reuse the existing `confidence_avg` auto-disable pattern: they return `None` when `status/devgraph.json` is absent, so weights renormalize over the original nine and **every current score is byte-identical**. The `unbuilt_specs` cap only fires once a dev graph exists. Result: zero behavioral change for any repo that hasn't built anything yet (including this methodology repo).

## Testing

`pytest tests/test_readiness.py` — **11 passed** (7 baseline unchanged + 4 new). Orchestrator runs clean end-to-end with the dimensions correctly `not_applicable`. *(Requires `pyyaml`; system Python here lacked it, so tests ran in a venv.)*

## Not in this PR (next step)

The `prd-v07-build-graph` extractor that actually *produces* `devgraph.json` (Graphify-style AST pass + `@implements` tag harvest + ARC conformance check + status derivation). The contract (`docs/DEVELOPMENT_GRAPH.md` §11–12) and the scorer are both ready to receive it.

## Reviewer notes

- Weights in `EPIC_WEIGHTS` are intentionally additive (raw sum 1.15) — they're relative and renormalized at runtime; a comment explains this.
- The `ARC-004` "engine/ must not import vscode" example throughout is the real conformance-rule pattern from the VS Code extension product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
