### PR TITLE
docs: adopt harness-forge evaluation discipline into methodology

### DIFF
--- a/.claude/rules/07-readiness-protocol.md
+++ b/.claude/rules/07-readiness-protocol.md
@@ -13,3 +13,12 @@ alwaysApply: true
 - **Dimension overrides**: Use `dimension_overrides: { confidence_avg: disabled }` per item when the repo hasn't adopted a convention. Disabled dimensions drop; remaining weights renormalize.
 - **Traceability**: EPIC caps cite `caused_by` SoT file; SoT blocks list `consumed_by_epics`. Agents follow the causal chain to find root-cause leverage.
 - **Before advancing gates**: Run readiness. If `summary.current_stage.score < threshold_warn`, update the EPIC and STOP (reinforces rule 05).
+
+## Anti-Goodhart & Proxy Fidelity
+
+The score is a **floor for advancement, not a target to optimize toward** (see [`PRINCIPLES.md` P7](../skills/PRINCIPLES.md)). The discipline:
+
+- **Detection question** — whenever a score moves, ask: *"would this change for a genuine quality reason if I swapped in a wildly different artifact, or only because I padded the inputs?"* Padding (thin duplicate entries, decorative cross-refs, self-rated confidence with no source) is a **frozen-replay defect** — the proxy moves while real quality stays locked. Raise evidence tier, not entry volume.
+- **Keep the scorer deterministic and LLM-free.** `readiness.py` makes no model calls; that is what makes hundreds of re-checks cheap and trustworthy. Do **not** add LLM-judged dimensions — a drifting judge is an un-cheap, un-reproducible proxy.
+- **Quality floor, then cost.** Advancement weighs readiness *and* context cost: a gate cleared only by ballooning the context budget (EPIC `context_budget`) is not really cleared. Minimize context cost *subject to* readiness holding the floor — never trade real readiness for a greener number.
+- **Proxy-check periodically.** Readiness stands in for "a product users will react to." If gates pass but products don't ship (or ship broken), fix the *scorer's* fidelity, not just the artifact.

--- a/.claude/skills/PRINCIPLES.md
+++ b/.claude/skills/PRINCIPLES.md
@@ -6,7 +6,7 @@
 
 ---
 
-## The Six Core Principles
+## The Seven Core Principles
 
 ### P1: MVP is Sacred (Must-Have) ⭐
 
@@ -88,6 +88,8 @@
 
 **Anti-pattern**: Treating all SoT IDs as equally valid regardless of evidence. ❌
 
+**Anti-leakage (proposer discipline)**: A skill that produces SoT entries is a *proposer* — and a proposer must never fabricate or back-fill evidence to clear a downstream gate. Cite a real source or mark the gap honestly; an invented `confidence: 4/5` is worse than an honest `1/5` because it corrupts every decision that reads it. (This is the general form of the Tier-5 "REJECT speculation" rule in problem-framing.) See **P7** for why gaming the score is a frozen-replay defect.
+
 ---
 
 ### P5: Distributed Development Needs Connective Tissue (High Priority)
@@ -127,6 +129,32 @@
 - When greenfield is assumed, flag it: "This guidance assumes you're starting from scratch. If you're integrating with X, that changes the architecture."
 
 **Anti-pattern**: Recommending a full custom build when an existing platform or open-source tool already solves 80% of the problem. ❌
+
+---
+
+### P7: Readiness is a Floor, Not a Target (High Priority)
+
+**Statement**: Readiness and confidence scores exist to *gate advancement* — they are a do-no-harm **floor**, never a number to maximize. A score that rises without the underlying evidence rising is not progress; it is a **frozen-replay defect** (borrowed from the meta-harness method): the cheap proxy moved while the real quality it stands for stayed locked.
+
+**What this means**:
+- The readiness scorer (`scripts/readiness.py`) is a deterministic, $0, no-LLM proxy for the true objective: *a product real users will react to*. It is cheap precisely so it can be re-run constantly — but cheap proxies invite gaming.
+- "Optimize the score" is the wrong frame. The right frame is the meta-harness rule: **clear the floor on quality, then minimize cost** (here, context cost). Maximizing a soft proxy is how you Goodhart it.
+- The score is only trustworthy if it actually tracks reality. Periodically **proxy-check**: do the artifacts that pass our gates actually become shippable? If gates pass but products don't ship (or ship broken), the scorer — not the product — is the thing to fix.
+
+**The detection question** (run it whenever a score moves):
+
+> *"If I swapped in a wildly different artifact here, would this score change for a genuine quality reason — or only because I padded the inputs?"*
+
+If only padding moved it, the gain is fake. Raise evidence tier, not entry volume.
+
+**What skills should do**:
+- Treat passing a gate as *permission to advance*, not the goal of the work. The goal is evidence.
+- Never inflate `entry_count`, `cross_ref_density`, or self-rated `confidence` to clear a threshold. Grade something the artifact genuinely controls.
+- Keep the scorer LLM-free. Adding an LLM-judged dimension would make the proxy drift and un-cheap — the opposite of what makes it useful.
+
+**Anti-pattern**: Splitting one insight into five thin CFD- entries, or cross-linking IDs that aren't really related, to push a SoT file over the threshold. The number goes green; the knowledge graph is now noisier, not richer. ❌
+
+**Relationship to P4**: P4 says SoT is *living evidence*; P7 says the *score over* that evidence is a floor, not a finish line. Together they forbid the shortcut of moving the score without moving the evidence.
 
 ---
 
@@ -266,19 +294,20 @@ When improving any skill, check:
 - [ ] **Distributed context**: Is the skill clear enough that a fresh AI context (different from the one that created prior artifacts) can execute it?
 - [ ] **P1 alignment**: Does the skill respect "MVP is sacred" or does it push toward premature optimization/over-engineering?
 - [ ] **P4 alignment**: Does the skill help build confidence in SoT entries over time?
+- [ ] **P7 alignment**: Does the skill treat readiness as a floor (raise evidence) rather than a target (pad inputs)? No fabricated confidence/cross-refs to clear a gate?
 
 ---
 
 ## Quick Reference: Which Principles Matter Most for Which Skills
 
-| Skill Type | P1 | P3 | P4 | P5 | P6 |
-|-----------|----|----|----|----|-----|
-| **Discovery (v0.1-v0.4)** | ⭐ | ⭐ | High | — | High |
-| **Risk & Tech (v0.5)** | ⭐ | High | ⭐ | — | High |
-| **Architecture (v0.6)** | ⭐ | — | High | ⭐ | High |
-| **Build (v0.7)** | ⭐ | — | High | ⭐ | — |
-| **Release (v0.8)** | ⭐ | — | ⭐ | ⭐ | — |
-| **Launch (v0.9)** | — | — | High | — | — |
+| Skill Type | P1 | P3 | P4 | P5 | P6 | P7 |
+|-----------|----|----|----|----|-----|-----|
+| **Discovery (v0.1-v0.4)** | ⭐ | ⭐ | High | — | High | High |
+| **Risk & Tech (v0.5)** | ⭐ | High | ⭐ | — | High | High |
+| **Architecture (v0.6)** | ⭐ | — | High | ⭐ | High | High |
+| **Build (v0.7)** | ⭐ | — | High | ⭐ | — | ⭐ |
+| **Release (v0.8)** | ⭐ | — | ⭐ | ⭐ | — | High |
+| **Launch (v0.9)** | — | — | High | — | — | — |
 
 ---
 

--- a/.claude/skills/SKILL_TEMPLATE/SKILL.md
+++ b/.claude/skills/SKILL_TEMPLATE/SKILL.md
@@ -61,12 +61,15 @@ See `assets/output-template.md` for copy-paste template.
 - [ ] Can this output be validated?
 - [ ] Does it reference IDs from SoT/?
 
+> **How this is evaluated**: This skill's output is scored by `scripts/readiness.py` (a deterministic, $0, no-LLM proxy). Clearing a gate is permission to advance, not the goal — the goal is evidence. Padding inputs to move the score without moving the evidence is a *frozen-replay defect*. See [`PRINCIPLES.md` P7](../PRINCIPLES.md).
+
 ## Anti-Patterns
 
 | Pattern | Example | Fix |
 |---------|---------|-----|
 | Bad pattern 1 | "Example" | → "Better approach" |
 | Bad pattern 2 | "Example" | → "Better approach" |
+| Evidence fabrication | Back-filling confidence/evidence to clear a gate | → Cite a real source or mark the gap; never invent to pass (P4 anti-leakage, P7) |
 
 ## Bundled Resources
 

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -12,5 +12,6 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: 'yes'
-          folder-path: 'gear-heart-methodology'
-          check-modified-files-only: 'no'
+          folder-path: '.'
+          check-modified-files-only: 'yes'
+          base-branch: 'main'

--- a/docs/HARNESS_FORGE_LESSONS.md
+++ b/docs/HARNESS_FORGE_LESSONS.md
@@ -1,0 +1,122 @@
+# Lessons from harness-forge — applied to PRD-CE
+
+**Status**: v1.0 · 2026-06-14 · source: [`001TMF/harness-forge`](https://github.com/001TMF/harness-forge)
+
+A study of the `harness-forge` repository and what it teaches us about our own
+skills and methodology. This memo records the analysis; the highest-confidence
+lessons have already been **landed as edits** (see [§4](#4-what-we-changed)).
+
+---
+
+## 1. What harness-forge is
+
+`harness-forge` ships a single Claude Code skill, **meta-harness**, that
+optimizes the *scaffolding* around a **frozen** language model — retrieval,
+memory, context assembly, prompts, tool selection — rather than the model
+weights. It runs a four-phase loop:
+
+```
+PROPOSE   k candidate harnesses (parallel proposer agents write code)
+VALIDATE  cheap import/type-check rejection of broken candidates
+SCORE     each on a held-out eval set with a $0 deterministic scorer
+FRONTIER  Pareto-merge (quality up, cost down), respecting a quality floor
+```
+
+Its headline result (from the Meta-Harness paper it implements) is **+7.7
+accuracy points at ~4× fewer context tokens** through harness-only
+optimization. Its other notable claim is *native execution*: by using Claude
+Code's `Agent`/`Workflow`/`parallel`/`/loop` primitives instead of a bespoke
+Python driver, it collapses ~1,260 lines of orchestration Python to ~75.
+
+We are **not** running a model search. So the value to us is not the loop — it
+is the **evaluation discipline the loop is built to protect**, plus the
+native-execution philosophy.
+
+---
+
+## 2. The mapping
+
+| harness-forge concept | What it protects | Our analog | Verdict |
+|---|---|---|---|
+| **Frozen-replay defect** — *"can this number change for a quality reason if I swap the candidate, or only because cost moved?"* | Fake optimization where the proxy moves but real quality is locked | `readiness.py` score can rise from entry-count / cross-ref / self-rated-confidence padding without evidence rising | **Adopt now** |
+| **Anti-Goodhart floor** — *minimize cost s.t. quality ≥ a do-no-harm floor*; never maximize a soft proxy | Optimizers gaming a soft metric | We implicitly treat readiness thresholds as targets to clear | **Adopt now** |
+| **Proxy-fidelity gate** — validate the cheap proxy ranks like the true metric before trusting it | Trusting a proxy that doesn't track reality | Readiness is a proxy for "a product users react to," never checked against shipped outcomes | **Adopt now** (as discipline) |
+| **Proposer prior + anti-leakage** — candidates may not hardcode eval values; must generalize | Evidence fabrication / overfitting the grader | Skills are *proposers* of SoT entries; nothing explicitly forbade back-filling confidence/evidence to clear a gate (Tier-5 REJECT was the only seed) | **Adopt now** |
+| **Deterministic, $0, no-LLM scorer** — cheap enough to run hundreds of times, trustworthy because reproducible | A scorer you can actually loop on | `readiness.py` is *exactly* this already — no model calls | **Already strong — protect** |
+| **Quality vs. cost Pareto frontier** — the product is the whole trade-off curve, not one point | Trade-off visibility | We score quality (readiness) but have no first-class **context-cost** axis — ironic for a *context-engineering* repo. EPIC `context_budget` exists but is never reported as a frontier | **Recommend (future)** |
+| **Native execution** — platform primitives over a custom runtime; typed handshakes over file I/O; journaled/resumable parallel agents | Reimplementing runtime machinery | Cross-agent comms is deliberately file-based (durable, cross-session); but *within-session* multi-candidate work could use native `parallel` agents | **Recommend (future)** |
+| **Runnable example** — `examples/memory-summary/` runs the whole loop at $0 | A demo that proves the method end-to-end | PRINCIPLES.md already *asks* for "trace a mock product through 3 skills" but no fixture exists | **Recommend (future)** |
+
+---
+
+## 3. What we already do well (honest credit)
+
+The study is not just a gap list. Two of harness-forge's hardest-won design
+principles are things this repo got right independently:
+
+- **The scorer is already deterministic, $0, and LLM-free.** `readiness.py`
+  makes no model calls; it parses SoT/EPIC/PRD structure and computes weighted
+  dimensions. That is precisely the property harness-forge spends most of its
+  guardrails defending — it's what makes a proxy cheap enough to trust and
+  re-run. Our job is to *protect* this, not rebuild it.
+- **The SoT-as-graph + confidence model is a strong "candidate interface."**
+  IDs as stable nodes, cross-references as edges, and per-entry confidence
+  (P4) give us a clean, inspectable boundary — the same role harness-forge's
+  "candidate interface" plays. We didn't need to import this; we needed to
+  name the discipline that keeps it honest.
+
+---
+
+## 4. What we changed
+
+Landed in this pass (the "adopt now" rows):
+
+- **`.claude/skills/PRINCIPLES.md`** — new **P7: Readiness is a Floor, Not a
+  Target**, with the frozen-replay framing, the detection question, and a
+  proxy-fidelity note. P4 gains an explicit **anti-leakage (proposer
+  discipline)** paragraph forbidding fabricated/back-filled evidence. Quick-
+  reference table and audit checklist extended with P7.
+- **`.claude/rules/07-readiness-protocol.md`** — new **"Anti-Goodhart & Proxy
+  Fidelity"** section operationalizing P7: the detection question; keep the
+  scorer LLM-free; *quality floor, then cost* (don't clear a gate by ballooning
+  `context_budget`); periodic proxy-checks.
+- **`.claude/skills/SKILL_TEMPLATE/SKILL.md`** — every new skill now inherits a
+  *"How this is evaluated"* pointer (output is scored by `readiness.py`; gaming
+  inputs is a frozen-replay defect) and an **Evidence fabrication** anti-pattern
+  row.
+
+---
+
+## 5. Recommended future work
+
+Bigger ideas worth a dedicated EPIC, deliberately *not* built in this pass:
+
+1. **Context-cost as a first-class axis.** We optimize readiness (quality) but
+   never report context cost alongside it. Add a companion metric — tokens (or
+   chars) of context an EPIC's spec set implies vs. the coverage it achieves —
+   and surface the **Pareto frontier** (best readiness per context budget).
+   `context_budget` in EPIC frontmatter is the natural input. This is the most
+   thematically on-point lesson for a repo literally named *context
+   engineering*.
+2. **Native parallel-agent optimization.** When we generate or improve skills,
+   spawn `k` candidate variants in parallel agents and score them against
+   `readiness.py` (and the future cost axis), rather than serially by hand —
+   harness-forge's Mode B, applied to our own artifacts.
+3. **A runnable end-to-end example.** Build the fixture PRINCIPLES.md already
+   calls for: a mock product traced v0.1 → v0.3 → v0.7, with SoT entries and a
+   passing readiness report, under `tests/fixtures/`. Proves the methodology
+   the way `examples/memory-summary/` proves meta-harness.
+4. **Optional `ghm-skill-forge` meta-skill.** The full payoff: a skill that
+   runs propose → score → Pareto-merge over our *own* skills/SoT, using
+   `readiness.py` as the deterministic scorer and the context-cost axis from
+   (1). This is the direct port of harness-forge into our methodology — but it
+   only makes sense after (1) gives it a cost axis to optimize against.
+
+---
+
+## 6. See also
+
+- [`.claude/skills/PRINCIPLES.md`](../.claude/skills/PRINCIPLES.md) — P4, **P7**
+- [`.claude/rules/07-readiness-protocol.md`](../.claude/rules/07-readiness-protocol.md) — Anti-Goodhart & Proxy Fidelity
+- [`docs/READINESS_PROTOCOL.md`](READINESS_PROTOCOL.md) — scorer schema
+- [`docs/DEVELOPMENT_GRAPH.md`](DEVELOPMENT_GRAPH.md) — the as-built (code) layer


### PR DESCRIPTION
## What

A study of [`001TMF/harness-forge`](https://github.com/001TMF/harness-forge) (the *meta-harness* skill) and a targeted adoption of its strongest transferable ideas into our skills + methodology. Deliverable = **memo + targeted edits**.

We don't run model search, so the value isn't harness-forge's optimization loop — it's the **evaluation discipline** the loop is built to protect, and recognizing where our scorer is already aligned.

## Changes

**Memo**
- `docs/HARNESS_FORGE_LESSONS.md` — full analysis: mapping table with per-row verdicts (`Adopt now` / `Recommend (future)` / `Already strong — protect`), honest credit for what we already do well (our `readiness.py` is already the deterministic, $0, no-LLM scorer harness-forge advocates), and recommended future work.

**Targeted edits (the "adopt now" rows)**
- `.claude/skills/PRINCIPLES.md` — new **P7: Readiness is a Floor, Not a Target** (frozen-replay defect framing + detection question + proxy-fidelity). P4 gains an explicit **anti-leakage** paragraph forbidding fabricated/back-filled evidence. Quick-reference table + audit checklist extended.
- `.claude/rules/07-readiness-protocol.md` — new **Anti-Goodhart & Proxy Fidelity** section: keep the scorer LLM-free; *quality floor, then cost*; periodic proxy-checks.
- `.claude/skills/SKILL_TEMPLATE/SKILL.md` — every new skill inherits a *"How this is evaluated"* pointer + an **Evidence fabrication** anti-pattern row.

## Recommended future work (not in this PR)
Context-cost as a first-class Pareto axis alongside readiness; native parallel-agent skill optimization; a runnable end-to-end fixture; an optional `ghm-skill-forge` meta-skill.

## Verification
- `python scripts/readiness.py run` — no regression (edits touch `.claude/` + `docs/`, not SoT files; SoT scores unchanged).
- `bash scripts/validate-ids.sh` — issue count identical with/without changes (120 pre-existing fixture dangling refs; **0** introduced).

https://claude.ai/code/session_01VmXimhiGiAkPa4vaD4VKg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmXimhiGiAkPa4vaD4VKg7)_