### PR TITLE
Add guardrails to PRD architecture and tech skills to prevent over‑engineering

### DIFF
--- a/.claude/skills/prd-v05-technical-stack-selection/SKILL.md
+++ b/.claude/skills/prd-v05-technical-stack-selection/SKILL.md
@@ -97,6 +97,19 @@ Product Family Notes: Share component library and auth context across products u
 ```
 
 
+## Best-Practice Decision Guardrails
+
+Technology selection should reduce product risk, not showcase a maximal stack. For each TECH- entry, document the capability it serves, the risk it mitigates, and the cost of operating it. Prefer boring, proven, already-known technology unless an upstream FEA-/RISK- explicitly requires something else.
+
+**Restraint rules:**
+- Do not introduce a new datastore, queue, framework, or cloud service without a named feature/risk that the existing stack cannot satisfy.
+- Do not choose microservice-oriented infrastructure for an MVP unless independent scaling, ownership, compliance, or deployment cadence is already required.
+- Do not build commodity capabilities (auth, billing, email, analytics) unless they are differentiators or vendors fail a concrete requirement.
+- Treat migration, ops burden, hiring difficulty, and lock-in as first-class costs alongside subscription price.
+- When two options both satisfy constraints, choose the option the team can ship and operate with the least new knowledge.
+
+**Decision test:** every Build/New/Replace choice must say why Reuse/Buy/Integrate is insufficient *now*. If that cannot be stated clearly, downgrade to Reuse/Buy/Integrate or mark as Research with a bounded proof-of-concept.
+
 ## Workflow Overview
 
 1. **Discover Existing Assets** → Read SOT or interview user for current tech stack

--- a/.claude/skills/prd-v06-architecture-design/SKILL.md
+++ b/.claude/skills/prd-v06-architecture-design/SKILL.md
@@ -98,6 +98,21 @@ Status: Accepted
 ```
 
 
+## Architectural Restraint Guardrails
+
+Architecture exists to make the product easier to understand, safer to change, and cheaper to operate. It is not a place to maximize patterns, layers, or future-proofing. Before introducing a boundary, abstraction, queue, service, framework, or pattern, name the **current pain** or **credible near-term change** it absorbs. If you cannot name that evidence, leave the design simpler and document the trigger that would justify the heavier option later.
+
+**Default posture for MVPs:** choose the simplest design that satisfies the upstream FEA-/RISK-/TECH- constraints and remains testable. A monolith with clear module boundaries is usually stronger than premature microservices; direct code is usually stronger than an adapter around a single stable dependency; a managed service is usually stronger than rebuilding commodity infrastructure.
+
+**Abstraction must earn its place:**
+- Add an adapter only when provider switching is likely, the vendor boundary is strategically important, or testability requires isolating external I/O.
+- Add a service boundary only when ownership, deployment cadence, scaling profile, data boundary, or reliability requirements genuinely differ.
+- Add queues/events only when async decoupling, retry semantics, or fan-out is required; do not hide a simple synchronous flow behind an event bus.
+- Add CQRS/event sourcing/sagas only when read/write divergence, audit replay, or cross-service consistency requirements are concrete.
+- Prefer a plain function or module over a class hierarchy when variation is not yet present.
+
+**Two-way decision test:** every ARC- must state not only why the chosen pattern helps, but also why the simpler alternative falls short *now*. If the simpler alternative is adequate, choose it and record the future trigger for revisiting.
+
 ## Architecture Decision Categories
 
 | Category | What It Covers | Example Decisions |
@@ -322,9 +337,11 @@ Every high-priority risk should have an architectural response:
 | **Architecture astronaut** | Over-engineering for 1000x scale | Design for 10x current needs |
 | **Missing boundaries** | Everything can call everything | Define clear interfaces |
 | **Ignoring RISK-** | Architecture doesn't address risks | Map each High RISK- to ARC- |
-| **Vendor lock-in** | No abstraction over critical services | Add adapter layer for switching |
+| **Vendor lock-in** | Critical external dependency with high switching/testability risk | Add adapter only around strategic or volatile boundaries |
 | **Diagram without decisions** | Pretty pictures, no ARC- records | Every box needs documented rationale |
-| **Premature microservices** | 5 services for MVP | Start monolith, extract later |
+| **Premature microservices** | 5 services for MVP | Start monolith, extract only after ownership/scale/deployment evidence |
+| **Pattern shopping** | ARC- names a pattern but not the concrete pain it fixes | Revert to direct design or document the evidence-backed trigger |
+| **Single-use abstraction** | Interface/adapter/factory with one stable implementation | Inline it or keep it concrete until a second variant/test double/boundary exists |
 
 ## Quality Gates
 

--- a/.claude/skills/prd-v06-technical-specification/SKILL.md
+++ b/.claude/skills/prd-v06-technical-specification/SKILL.md
@@ -107,6 +107,20 @@ Business Rules: BR-015 (max 100 per user — enforce in API-001)
 APIs: API-001 (create), API-002 (get), API-003 (list), API-005 (delete)
 ```
 
+## Contract Simplicity Guardrails
+
+Technical specifications should give developers stable contracts without turning every possible future into a schema, endpoint, or layer today. Model the product described by UJ-/SCR-/BR-/ARC- evidence; avoid speculative extension points.
+
+**Keep contracts lean:**
+- Create endpoints from concrete user journeys and screens, not generic CRUD coverage for every table.
+- Add fields only when a screen, journey, business rule, integration, or audit requirement consumes them.
+- Prefer one coherent endpoint over several chatty endpoints when a screen needs an atomic view of data.
+- Prefer explicit domain endpoints over over-generic `/actions`, `/resources`, or filter-everything APIs.
+- Do not split read/write models, event streams, or background workflows unless ARC- entries document the present need.
+- Preserve public contract stability once specified; if a contract must change, record the upstream reason and migration impact.
+
+**Specification test:** for each API-/DBT- item, cite the upstream UJ-/SCR-/BR-/ARC-/TECH- that requires it. If no upstream consumer or rule exists, remove it or mark it as a deferred future trigger rather than part of the build contract.
+
 ## Specification Types
 
 | Type | What It Defines | Example |


### PR DESCRIPTION
### Motivation

- Reduce pattern‑shopping and premature abstractions in architecture and tech‑selection skills by requiring evidence that heavier designs solve a present pain or credible near‑term need. 
- Align skill guidance with pragmatic best practices (inspired by SOLIDIFIER learnings) so MVPs remain simple, testable, and operable. 
- Make API/DB contract work traceable to upstream consumers to avoid speculative endpoints and fields.

### Description

- Add `## Best‑Practice Decision Guardrails` to `.claude/skills/prd-v05-technical-stack-selection/SKILL.md` that require new tech/datastores/queues/frameworks to tie to concrete FEA-/RISK‑driven evidence and operational costs. 
- Add `## Architectural Restraint Guardrails` to `.claude/skills/prd-v06-architecture-design/SKILL.md` that require abstractions, service boundaries, queues, and advanced patterns to be justified by current pains or credible near‑term changes and introduce the two‑way decision test. 
- Add `## Contract Simplicity Guardrails` to `.claude/skills/prd-v06-technical-specification/SKILL.md` to keep API/DBT contracts lean and explicitly traceable to UJ-/SCR-/BR-/ARC-/TECH‑consumers. 
- Tighten anti‑pattern guidance by refining the vendor lock‑in and premature microservices rows and adding checks for `Pattern shopping` and `Single‑use abstraction` in the architecture anti‑patterns table.

### Testing

- Ran a targeted search for the new guardrail markers with `rg -n "Architectural Restraint Guardrails|Best-Practice Decision Guardrails|Contract Simplicity Guardrails|Pattern shopping|Single-use abstraction"` against the three modified skills and confirmed matches were present. 
- Ran `git diff --check` to ensure no whitespace or diff errors were introduced and the check returned clean. 
- Verified the three skill files updated are ` .claude/skills/prd-v05-technical-stack-selection/SKILL.md`, ` .claude/skills/prd-v06-architecture-design/SKILL.md`, and ` .claude/skills/prd-v06-technical-specification/SKILL.md` and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a579fc69d108326991ccca357f7625c)